### PR TITLE
ci: sign and notarize macOS builds with Developer ID

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,13 +90,19 @@ jobs:
         env:
           # Lets electron-builder create/update the draft release in this repo.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # ── macOS signing + notarization (optional) ──────────────────────
+          # ── macOS signing + notarization ─────────────────────────────────
           # Required for auto-update on macOS (Squirrel.Mac verifies the
-          # signature) and to avoid the Gatekeeper warning. To enable: add the
-          # secrets below, remove `mac.identity: null` from package.json, and
-          # uncomment these lines.
-          # CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
-          # CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
-          # APPLE_ID: ${{ secrets.APPLE_ID }}
-          # APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          # APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # signature) and to avoid the Gatekeeper warning. Empty on forks /
+          # when the secrets are unset: electron-builder then falls back to the
+          # ad-hoc signature from scripts/after-pack.cjs and skips notarization.
+          #
+          #   CSC_LINK                    base64 of the Developer ID .p12
+          #   CSC_KEY_PASSWORD            password set when exporting the .p12
+          #   APPLE_ID                    Apple ID email (notarization)
+          #   APPLE_APP_SPECIFIC_PASSWORD app-specific password for that Apple ID
+          #   APPLE_TEAM_ID               10-char Developer Team ID
+          CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!--
+    Entitlements for the hardened runtime that Apple requires for notarization.
+
+    Electron's V8 JITs JavaScript into executable memory, so without these the
+    notarized app crashes on launch. disable-library-validation lets the app
+    load the bundled native pieces (koffi addon, the ffprobe binary spawned as a
+    child process) that aren't signed with our team's cert.
+  -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "build": "vp pack",
     "build:ui": "vp build ui",
     "build:all": "vp run build && vp run build:ui",
-    "build:electron": "vp run build:all && node scripts/run-electron-builder.mjs",
-    "build:electron:dir": "vp run build:all && node scripts/run-electron-builder.mjs --dir",
+    "build:electron": "vp run build:all && cross-env CSC_IDENTITY_AUTO_DISCOVERY=false node scripts/run-electron-builder.mjs",
+    "build:electron:dir": "vp run build:all && cross-env CSC_IDENTITY_AUTO_DISCOVERY=false node scripts/run-electron-builder.mjs --dir",
     "electron": "vp run build:all && electron dist/electron/electron.mjs",
     "start": "node dist/server/index.mjs",
     "start:ui": "node dist/server/index.mjs --ui",
@@ -154,8 +154,11 @@
     "npmRebuild": false,
     "mac": {
       "category": "public.app-category.entertainment",
-      "identity": null,
       "icon": "build/icon.icns",
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
+      "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.plist",
       "target": [
         "dmg",
         "zip"

--- a/scripts/after-pack.cjs
+++ b/scripts/after-pack.cjs
@@ -21,6 +21,13 @@ exports.default = async function afterPack(context) {
   if (context.electronPlatformName !== 'darwin') {
     return
   }
+  // When a real Developer ID cert is provided (CI), electron-builder signs the
+  // bundle itself with the hardened runtime + entitlements and then notarizes.
+  // A pre-emptive ad-hoc signature here is pointless (it gets overwritten) and
+  // would only muddy the logs, so leave signing to electron-builder.
+  if (process.env.CSC_LINK || process.env.CSC_NAME) {
+    return
+  }
   const appPath = path.join(context.appOutDir, `${context.packager.appInfo.productFilename}.app`)
   // Sign inside-out is what electron-builder normally does; for a plain ad-hoc
   // pass `--deep` is sufficient to seal the nested helpers/framework.

--- a/scripts/run-electron-builder.mjs
+++ b/scripts/run-electron-builder.mjs
@@ -131,10 +131,25 @@ if (!existsSync(resolvedBin)) {
   process.exit(1)
 }
 
+// Notarization is gated on the Apple credentials being present: it only runs in
+// CI where the secrets are wired up, never on a contributor's local `pnpm
+// build:electron`. electron-builder reads the APPLE_ID / APPLE_TEAM_ID env vars
+// itself; we just flip `mac.notarize` on so it actually submits the build.
+const passthroughArgs = process.argv.slice(2)
+const canNotarize =
+  process.platform === 'darwin' &&
+  process.env.APPLE_ID &&
+  process.env.APPLE_APP_SPECIFIC_PASSWORD &&
+  process.env.APPLE_TEAM_ID
+if (canNotarize) {
+  passthroughArgs.push('-c.mac.notarize=true')
+  console.log('[run-electron-builder] Apple credentials detected — enabling notarization')
+}
+
 // shell:true is required on Windows because Node 18.20.2+ refuses to spawn
 // .cmd/.bat files directly (CVE-2024-27980 mitigation). resolvedBin is the
 // ASCII short path, so cmd's bat-content codepage no longer matters here.
-const child = spawn(resolvedBin, process.argv.slice(2), {
+const child = spawn(resolvedBin, passthroughArgs, {
   env,
   stdio: 'inherit',
   shell: isWindows,


### PR DESCRIPTION
## Что

Включает настоящую подпись **Developer ID Application** + нотаризацию для macOS-релизов. Раньше macOS-сборка подписывалась только ад-хок (`scripts/after-pack.cjs`), из-за чего Gatekeeper показывал предупреждение и не работало автообновление (Squirrel.Mac проверяет подпись).

## Изменения

- **`package.json`** (`build.mac`): убран `identity: null`, включён `hardenedRuntime`, `gatekeeperAssess: false`, заданы `entitlements`/`entitlementsInherit`.
- **`build/entitlements.mac.plist`** (новый): entitlements для hardened runtime — JIT V8, unsigned executable memory, `disable-library-validation` (загрузка нативного koffi-аддона и запуск бинарника ffprobe).
- **`scripts/after-pack.cjs`**: ад-хок подпись пропускается, когда есть настоящий сертификат (`CSC_LINK`/`CSC_NAME`) — подписывает сам electron-builder.
- **`scripts/run-electron-builder.mjs`**: нотаризация включается только при наличии Apple-кред (в CI), локальные сборки её не запускают.
- **`package.json`** (скрипты `build:electron*`): `CSC_IDENTITY_AUTO_DISCOVERY=false`, чтобы локальные сборки оставались ад-хок и не цепляли Developer ID из Keychain.
- **`.github/workflows/release.yml`**: проброшены секреты подписи и нотаризации.

## Секреты (уже добавлены в репозиторий)

`MAC_CSC_LINK`, `MAC_CSC_KEY_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID` (Team ID `62687D298A`).

На форках/без секретов CI безопасно откатывается на ад-хок подпись и пропускает нотаризацию.

## Как проверить после мёрджа

```bash
git tag v0.0.2 && git push origin v0.0.2
```
В логах macOS-джобы должно появиться `Apple credentials detected — enabling notarization`. На скачанном `.dmg`:
```bash
spctl -a -vvv -t install "MyShows Scrobbler.app"   # accepted, source=Notarized Developer ID
xcrun stapler validate "MyShows Scrobbler.app"
```