### PR TITLE
chore: v0.0.4 — notify once per update version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "myshows-scrobbler",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Universal media scrobbler for MyShows (Plex, Emby, Jellyfin, Kodi)",
   "keywords": [
     "emby",

--- a/src/electron.ts
+++ b/src/electron.ts
@@ -254,6 +254,11 @@ function createUpdateController(): {
   start: (logger: Logger) => void
 } {
   const skipped = loadSkippedUpdates()
+  // Versions we've already shown a native notification for this session. The
+  // periodic re-check (every 6h) re-fires `update-available` for the same
+  // version; without this the user would get the same popup every 6h until
+  // they act. In-memory on purpose — one reminder per app launch is fine.
+  const notifiedVersions = new Set<string>()
 
   const controller: UpdateController = {
     getStatus: () => ({ ...updateStatus }),
@@ -295,7 +300,10 @@ function createUpdateController(): {
       }
       updateStatus = { available: true, version: info.version, downloading: false }
       logger.info(`Update available: ${info.version}`)
-      if (Notification.isSupported()) {
+      // The in-app dot + banner always reflect availability; the native popup
+      // only fires the first time we see a given version, not on every re-check.
+      if (Notification.isSupported() && !notifiedVersions.has(info.version)) {
+        notifiedVersions.add(info.version)
         // Refresh the language from the renderer first (if the window is still
         // alive) so the notice matches the in-app choice, not just the OS locale.
         void syncUiLocale().finally(() => {


### PR DESCRIPTION
## Release v0.0.4

Бамп `0.0.3 → 0.0.4` + фикс повторяющихся уведомлений об обновлении.

### Что чинит
6ч-перепроверка повторно генерировала событие `update-available` для той же версии, поэтому пользователь, который игнорировал апдейт (но не нажал «Пропустить»), получал **то же нативное уведомление каждые 6 часов**.

Теперь нативный popup показывается **только при первом обнаружении** версии (трекаем `notifiedVersions` в памяти). Точка в шапке и баннер по-прежнему отражают доступность постоянно.

### Проверки
- ✅ `pnpm check` — формат/линт/типы (0 ошибок)
- ✅ `pnpm test` — 311 тестов passed
- ✅ `pnpm build` — electron-бандл собирается

### Тест после релиза
Установлена 0.0.3 (с рабочим one-click self-install на macOS). После публикации 0.0.4 проверяем end-to-end: уведомление → точка/баннер → кнопка «Обновить» → self-install на macOS.