### PR TITLE
chore: v0.0.5 — unobtrusive update UX + banner hover fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "myshows-scrobbler",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Universal media scrobbler for MyShows (Plex, Emby, Jellyfin, Kodi)",
   "keywords": [
     "emby",

--- a/src/electron.ts
+++ b/src/electron.ts
@@ -254,11 +254,6 @@ function createUpdateController(): {
   start: (logger: Logger) => void
 } {
   const skipped = loadSkippedUpdates()
-  // Versions we've already shown a native notification for this session. The
-  // periodic re-check (every 6h) re-fires `update-available` for the same
-  // version; without this the user would get the same popup every 6h until
-  // they act. In-memory on purpose — one reminder per app launch is fine.
-  const notifiedVersions = new Set<string>()
 
   const controller: UpdateController = {
     getStatus: () => ({ ...updateStatus }),
@@ -300,16 +295,22 @@ function createUpdateController(): {
       }
       updateStatus = { available: true, version: info.version, downloading: false }
       logger.info(`Update available: ${info.version}`)
-      // The in-app dot + banner always reflect availability; the native popup
-      // only fires the first time we see a given version, not on every re-check.
-      if (Notification.isSupported() && !notifiedVersions.has(info.version)) {
-        notifiedVersions.add(info.version)
+      // Only nudge with a native popup when the window is hidden (parked in the
+      // tray / minimized). If it's open, the in-app dot + banner already show the
+      // update, so a popup would be redundant. The 6h re-check keeps re-firing
+      // this event, so a tray user gets a quiet reminder every 6h until they act
+      // (Install downloads; Skip adds the version to `skipped` above).
+      const windowHidden = !mainWindow || !mainWindow.isVisible() || mainWindow.isMinimized()
+      if (Notification.isSupported() && windowHidden) {
         // Refresh the language from the renderer first (if the window is still
         // alive) so the notice matches the in-app choice, not just the OS locale.
         void syncUiLocale().finally(() => {
           const note = new Notification({
             title: 'MyShows Scrobbler',
             body: UPDATE_AVAILABLE_BODY[getUiLocale()](info.version),
+            // Silent: the app lives in the tray long-term, so an update is a
+            // low-urgency heads-up — a soundless nudge, not an alert.
+            silent: true,
           })
           note.on('click', restoreMainWindow)
           note.show()

--- a/ui/src/components/core/AppShell.vue
+++ b/ui/src/components/core/AppShell.vue
@@ -640,13 +640,22 @@ function onTokenEdit(value: string) {
     font-weight: 600;
     padding: 5px 12px;
     border-radius: 7px;
-    border: 1px solid var(--v2-border-soft);
-    background: transparent;
-    color: var(--v2-text);
+    border: 1px solid var(--v2-border-strong, #cfcfd4);
+    background: var(--v2-bg, #fff);
+    // Fallback guards against the global `button { color: var(--color-text) }`
+    // reset (white) leaking in if the custom property fails to resolve.
+    color: var(--v2-text, #1a1a1d);
     cursor: pointer;
+    transition:
+      background-color 0.12s,
+      border-color 0.12s;
 
+    // Always restate color on hover so the dark text can never fall back to the
+    // global white default — that was making the label invisible.
     &:hover:not(:disabled) {
-      background: var(--v2-bg-stripe);
+      background: var(--v2-bg-stripe, #f7f7f8);
+      border-color: var(--v2-border-strong, #cfcfd4);
+      color: var(--v2-text, #1a1a1d);
     }
     &:disabled {
       opacity: 0.55;
@@ -654,12 +663,16 @@ function onTokenEdit(value: string) {
     }
 
     &--primary {
-      background: var(--v2-brand);
-      border-color: var(--v2-brand);
+      background: var(--v2-brand, #e63946);
+      border-color: var(--v2-brand, #e63946);
       color: #fff;
 
+      // Darken on hover (white text stays high-contrast) instead of a faint
+      // brightness filter that washed the button out.
       &:hover:not(:disabled) {
-        filter: brightness(1.06);
+        background: var(--v2-brand-dark, #c62731);
+        border-color: var(--v2-brand-dark, #c62731);
+        color: #fff;
       }
     }
   }


### PR DESCRIPTION
## Release v0.0.5

Бамп `0.0.4 → 0.0.5`. Ненавязчивый UX уведомлений об обновлении + фикс ховера кнопок баннера.

### Уведомление об обновлении
- **silent** (без звука) — апдейт это низкоприоритетный сигнал.
- Показывается **только когда окно скрыто** (трей/свёрнуто). Если окно открыто — апдейт уже виден через точку в шапке + баннер, popup не нужен.
- **Повторяется каждые 6ч**, пока пользователь не нажал «Обновить» или «Пропустить» — тихое напоминание для тех, кто в трее (откат дедупа «один раз на версию» из 0.0.4).

### Ховер кнопок баннера
- На `:hover` цвет текста задаётся явно с фолбэками, чтобы глобальный `button { color: var(--color-text) }` (белый) не «протекал» и не делал текст невидимым.
- Primary-кнопка на ховере затемняется до `--v2-brand-dark` вместо еле заметного `filter: brightness`.

### Проверки
- ✅ `pnpm check` — формат/линт/типы (0 ошибок)
- ✅ `pnpm test` — 311 тестов passed
- ✅ `pnpm build:all` (server + UI)

### Проверка после релиза
Обновление с 0.0.4 → 0.0.5: при свёрнутом окне — тихий popup; при открытом — только баннер; ховер кнопок читаемый.