### PR TITLE
chore: v0.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "myshows-scrobbler",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Universal media scrobbler for MyShows (Plex, Emby, Jellyfin, Kodi)",
   "keywords": [
     "emby",


### PR DESCRIPTION
Release v0.0.7 — bumps `package.json` to 0.0.7 so the tag can be cut from main.

### Included (already on main since v0.0.6)
- **fix:** prevent CRLF line endings from breaking the Docker entrypoint on Windows (#daf7445)
- **chore:** consolidate oxlint/oxfmt config into `vite.config.ts`; fix VS Code format-on-save (#8)

After merge, tag `v0.0.7` on main → the Release workflow builds the Windows/macOS/Linux installers into a draft.