### PR TITLE
feat: skip short clips, finalize scrobble at threshold, and filter ou…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "myshows-scrobbler",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Universal media scrobbler for MyShows (Plex, Emby, Jellyfin, Kodi)",
   "keywords": [
     "emby",

--- a/scripts/windows-smtc-probe.ps1
+++ b/scripts/windows-smtc-probe.ps1
@@ -13,6 +13,7 @@
 #       "title": string,
 #       "artist": string,
 #       "albumTitle": string,
+#       "playbackType": string,   # "Music" | "Video" | "Image" | "Unknown" | ""
 #       "isPlaying": boolean,
 #       "positionSeconds": number,
 #       "durationSeconds": number
@@ -95,12 +96,16 @@ foreach ($s in $sessions) {
         $title = ''
         $artist = ''
         $albumTitle = ''
+        $playbackType = ''
         if ($mediaProps) {
             $title = if ($null -ne $mediaProps.Title) { $mediaProps.Title } else { '' }
             $artist = if ($null -ne $mediaProps.Artist) { $mediaProps.Artist } else { '' }
             # Modern Windows Media Player and some streaming apps publish the
             # show name in AlbumTitle (e.g. series title with Title=episode).
             $albumTitle = if ($null -ne $mediaProps.AlbumTitle) { $mediaProps.AlbumTitle } else { '' }
+            # Media kind reported by the app: "Music" / "Video" / "Image" /
+            # "Unknown". Lets us drop songs without guessing from the app id.
+            $playbackType = if ($null -ne $mediaProps.PlaybackType) { $mediaProps.PlaybackType.ToString() } else { '' }
         }
 
         $timeline = $s.GetTimelineProperties()
@@ -121,6 +126,7 @@ foreach ($s in $sessions) {
             title = $title
             artist = $artist
             albumTitle = $albumTitle
+            playbackType = $playbackType
             isPlaying = [bool]$isPlaying
             positionSeconds = $positionSeconds
             durationSeconds = $durationSeconds

--- a/src/adapters/emby.ts
+++ b/src/adapters/emby.ts
@@ -1,5 +1,6 @@
 import type { SourceType } from '../types.js'
 import { JellyfinAdapter, type JellyfinItem, type JellyfinSession } from './jellyfin.js'
+import { isScrobblableType } from './media-info.js'
 import { fetchWithTimeout } from '../http.js'
 
 export class EmbyAdapter extends JellyfinAdapter {
@@ -25,6 +26,6 @@ export class EmbyAdapter extends JellyfinAdapter {
     const sessions = (await response.json()) as Array<
       JellyfinSession & { NowPlayingItem?: JellyfinItem }
     >
-    return sessions.filter((s) => s.NowPlayingItem)
+    return sessions.filter((s) => s.NowPlayingItem && isScrobblableType(s.NowPlayingItem.Type))
   }
 }

--- a/src/adapters/jellyfin.ts
+++ b/src/adapters/jellyfin.ts
@@ -2,7 +2,12 @@ import type { SourceType, NormalizedEvent, PlaybackState, MediaInfo } from '../t
 import { BaseAdapter } from './base.js'
 import { extractDubTeam } from '../utils/dub-team.js'
 import { idsFromProviderIds, legacyIdFields } from './external-ids.js'
-import { hdrFromText, mediaInfoOrNull, resolutionFromDimensions } from './media-info.js'
+import {
+  hdrFromText,
+  isScrobblableType,
+  mediaInfoOrNull,
+  resolutionFromDimensions,
+} from './media-info.js'
 import { languageToIso } from '../utils/audio-track.js'
 import { percentFromPosition, ticksToMs, ticksToRuntimeMinutes } from './time.js'
 import { fetchWithTimeout } from '../http.js'
@@ -342,6 +347,6 @@ export class JellyfinAdapter extends BaseAdapter {
     }
 
     const sessions = (await response.json()) as JellyfinSession[]
-    return sessions.filter((s) => s.NowPlayingItem)
+    return sessions.filter((s) => s.NowPlayingItem && isScrobblableType(s.NowPlayingItem.Type))
   }
 }

--- a/src/adapters/kodi.ts
+++ b/src/adapters/kodi.ts
@@ -5,6 +5,7 @@ import { idsFromKodiUniqueIds, legacyIdFields, nonEmptyString } from './external
 import {
   containerFromFile,
   hdrFromText,
+  isScrobblableType,
   mediaInfoOrNull,
   resolutionFromDimensions,
 } from './media-info.js'
@@ -357,7 +358,9 @@ export class KodiAdapter extends BaseAdapter {
         ],
       })
 
-      if (itemResult?.item && props) {
+      // Video player can still hold a `musicvideo` (or other non-show item);
+      // MyShows only takes movies and episodes.
+      if (itemResult?.item && props && isScrobblableType(itemResult.item.type)) {
         sessions.push({
           playerId: player.playerid,
           item: itemResult.item,

--- a/src/adapters/media-info.ts
+++ b/src/adapters/media-info.ts
@@ -149,3 +149,15 @@ export function containerFromFile(filePath?: string): string | null {
 export function mediaInfoOrNull(info: MediaInfo): MediaInfo | null {
   return Object.values(info).some((value) => value != null) ? info : null
 }
+
+/**
+ * True only for content MyShows can scrobble. Sources report many other kinds
+ * (`track`/`song`/`musicvideo`/`clip`/`photo`/`audio`/…); without this guard the
+ * adapters' `normalizeType` helpers would silently coerce them all to `movie`.
+ * Case-insensitive so it works for Plex/Kodi (lowercase) and Jellyfin/Emby
+ * (PascalCase) alike.
+ */
+export function isScrobblableType(type: string | undefined): boolean {
+  const t = type?.toLowerCase()
+  return t === 'movie' || t === 'episode'
+}

--- a/src/adapters/mpc-http.ts
+++ b/src/adapters/mpc-http.ts
@@ -10,7 +10,7 @@ import {
   resolutionFromFilename,
 } from './media-info.js'
 import { dubTeamFromTrackTitle, languageToIso, normalizeAudioCodec } from '../utils/audio-track.js'
-import { probeFileMedia, type FileMediaProbe } from '../utils/media-duration.js'
+import { isProbedAudioOnly, probeFileMedia, type FileMediaProbe } from '../utils/media-duration.js'
 
 /**
  * MPC-HC / MPC-BE / MPC-QT HTTP source.
@@ -146,6 +146,12 @@ export function buildEvent(
   // adapter shouldn't emit phantom events for that case.
   const pathOrName = snapshot.filepath || snapshot.file
   if (!pathOrName) {
+    return null
+  }
+
+  // A song, not a show or movie (probe found audio but no real video stream).
+  // Without a probe (no path or no ffprobe) we can't tell, so we let it through.
+  if (isProbedAudioOnly(probe)) {
     return null
   }
 

--- a/src/adapters/mpv-ipc.ts
+++ b/src/adapters/mpv-ipc.ts
@@ -37,9 +37,28 @@ export function resolveMpvSocket(rawUrl: string): string {
 }
 
 /**
+ * True when the snapshot is positively audio-only: mpv reports an audio track
+ * but no real video (cover art counts as no video). Keeps music out of the
+ * scrobble feed. A still-loading video also reports no params, so we only call
+ * it music when an audio track is actually present — better to keep a real
+ * video than to drop one.
+ */
+export function isAudioOnly(props: MpvProperties): boolean {
+  if (props.videoAlbumart === true) {
+    return true
+  }
+  const hasVideo =
+    props.videoWidth != null ||
+    props.videoHeight != null ||
+    props.videoGamma != null ||
+    props.doviProfile != null
+  return !hasVideo && props.audioCodec != null
+}
+
+/**
  * Build a NormalizedEvent from an mpv property snapshot. Pure — no IPC, no
  * state — so the data path is unit-testable. Returns null when there's no
- * file loaded (idle mpv).
+ * file loaded (idle mpv) or the file is music.
  */
 export function buildEvent(
   props: MpvProperties,
@@ -48,6 +67,10 @@ export function buildEvent(
 ): NormalizedEvent | null {
   const pathOrTitle = props.path ?? props.mediaTitle
   if (!pathOrTitle) {
+    return null
+  }
+  // Music (audio-only or cover-art "video") is not a show/movie — skip it.
+  if (isAudioOnly(props)) {
     return null
   }
   const parsed = parseFilename(pathOrTitle)

--- a/src/adapters/player.ts
+++ b/src/adapters/player.ts
@@ -22,12 +22,13 @@ import {
 import {
   getActiveDurationTool,
   getMediaDurationSeconds,
+  isProbedAudioOnly,
   probeFileMedia,
   type FileMediaProbe,
 } from '../utils/media-duration.js'
 import { dubTeamFromTrackTitle, languageToIso, normalizeAudioCodec } from '../utils/audio-track.js'
 import { probeMacosPlayers, type OsaPlayback } from '../utils/macos-osa.js'
-import { probeLinuxMpris, type MprisPlayback } from '../utils/linux-mpris.js'
+import { probeLinuxMpris, type MprisPlayback, type MprisPlayerKind } from '../utils/linux-mpris.js'
 import { probeWindowsSmtc, classifyAumid, type SmtcPlayback } from '../utils/windows-smtc.js'
 import { probeWindowsPotPlayer } from '../utils/windows-potplayer.js'
 import { resolveWindowsFilePath } from '../utils/windows-handle-resolver.js'
@@ -48,6 +49,13 @@ import { resolveWindowsFilePath } from '../utils/windows-handle-resolver.js'
  * internals.
  */
 export const SMTC_SKIP_PLAYERS: PlayerId[] = ['spotify', 'browser']
+
+/**
+ * MPRIS player kinds we ignore — dedicated music players that never carry a
+ * show/movie. Audio files opened in a *video* MPRIS player still get caught by
+ * the downstream ffprobe music guard.
+ */
+export const MPRIS_SKIP_PLAYERS: MprisPlayerKind[] = ['rhythmbox']
 
 /**
  * Sentinel filePath for the PotPlayer SendMessage reading. That probe returns
@@ -131,6 +139,11 @@ async function gatherPreciseSessions(): Promise<PreciseRegistry> {
   }
 
   for (const mp of await probeLinuxMpris()) {
+    // Music players have nothing to scrobble to MyShows. A local audio file
+    // opened in a video player is still caught later by the ffprobe gate.
+    if (MPRIS_SKIP_PLAYERS.includes(mp.player)) {
+      continue
+    }
     // MPRIS may or may not expose `xesam:url`. With a path we merge against
     // the process scan's filePath; without it we merge by player id (same
     // semantics as SMTC below).
@@ -147,6 +160,11 @@ async function gatherPreciseSessions(): Promise<PreciseRegistry> {
     // Drop sources SMTC can't describe well enough to scrobble — see
     // SMTC_SKIP_PLAYERS for the per-player rationale.
     if (SMTC_SKIP_PLAYERS.includes(player)) {
+      continue
+    }
+    // SMTC tells us the media kind directly — drop anything that isn't video
+    // (music apps, photo viewers) regardless of which app reported it.
+    if (s.playbackType === 'Music' || s.playbackType === 'Image') {
       continue
     }
     // Skip empty-title sessions (nothing to scrobble) and zero-duration
@@ -384,12 +402,12 @@ export class PlayerAdapter extends BaseAdapter {
    */
   private firstSessionByPid = new Map<number, string>()
   /**
-   * sessionIds that have already emitted a final 'stopped' via uptime
-   * saturation. We refuse to recreate them on subsequent polls — otherwise
-   * an MPC left open for 24h with the same file would generate one false
-   * "watched" scrobble per duration-of-wall-clock. Cleared when the pid
-   * actually disappears, or the user opens a different file (different
-   * sessionId).
+   * sessionIds we're done with and won't recreate on later polls. Two reasons
+   * land here: a session that emitted its final 'stopped' via uptime saturation
+   * (otherwise an MPC left open for 24h would scrobble the same file once per
+   * wall-clock duration), and a session we identified as music (so we don't
+   * re-probe and re-log a song every tick). Cleared when the pid disappears or
+   * the user opens a different file (different sessionId).
    */
   private completedSessionIds = new Set<string>()
   private warnedNoTool = false
@@ -534,11 +552,18 @@ export class PlayerAdapter extends BaseAdapter {
         this.touchSession(session, preciseHit)
       }
 
+      // It's a song, not a show or movie (the probe found audio but no real
+      // video). Retire it so we don't re-detect and re-log it every tick, and
+      // never emit anything for it.
+      if (isProbedAudioOnly(session.probe)) {
+        this.retireSession(sessionId)
+        continue
+      }
+
       // Saturation closes the session as 'stopped' instead of 'progress'.
       // emitScrobble is wrapped in the same try/catch as the progress path.
       if (session.uptimeSaturated) {
-        this.completedSessionIds.add(sessionId)
-        this.sessions.delete(sessionId)
+        this.retireSession(sessionId)
         this.log(
           'info',
           `Uptime saturation: ${session.filePath} (${session.player}) — emitting final 'stopped' and freezing this session. ` +
@@ -625,6 +650,12 @@ export class PlayerAdapter extends BaseAdapter {
         this.completedSessionIds.delete(id)
       }
     }
+  }
+
+  /** Stop tracking a session and refuse to recreate it on later polls. */
+  private retireSession(sessionId: string): void {
+    this.completedSessionIds.add(sessionId)
+    this.sessions.delete(sessionId)
   }
 
   private async startSession(
@@ -725,6 +756,12 @@ export class PlayerAdapter extends BaseAdapter {
     const sessionId = buildOrphanSessionId(precise.player, precise.filePath)
     seen.add(sessionId)
 
+    // Already finished with this one (music, or uptime-saturated) — don't
+    // recreate it.
+    if (this.completedSessionIds.has(sessionId)) {
+      return
+    }
+
     let session = this.sessions.get(sessionId)
     if (!session) {
       session = await this.startOrphanSession(sessionId, ORPHAN_PID, precise)
@@ -732,6 +769,13 @@ export class PlayerAdapter extends BaseAdapter {
     } else {
       session.missedTicks = 0
       this.touchSession(session, precise)
+    }
+
+    // A local song opened in VLC/QuickTime, or an MPRIS orphan pointing at an
+    // audio file — retire it and skip it from here on.
+    if (isProbedAudioOnly(session.probe)) {
+      this.retireSession(sessionId)
+      return
     }
 
     try {

--- a/src/adapters/plex.ts
+++ b/src/adapters/plex.ts
@@ -2,7 +2,7 @@ import type { SourceType, NormalizedEvent, PlaybackState, MediaInfo } from '../t
 import { BaseAdapter } from './base.js'
 import { extractDubTeam } from '../utils/dub-team.js'
 import { extractPrefixedId, idsFromPrefixedGuids, legacyIdFields } from './external-ids.js'
-import { hdrFromText } from './media-info.js'
+import { hdrFromText, isScrobblableType } from './media-info.js'
 import { languageToIso } from '../utils/audio-track.js'
 import { msToRuntimeMinutes, percentFromPosition } from './time.js'
 import { fetchWithTimeout } from '../http.js'
@@ -481,10 +481,15 @@ export class PlexAdapter extends BaseAdapter {
     const data = (await response.json()) as PlexSessionsResponse
     const sessions = data.MediaContainer?.Metadata ?? []
 
-    return sessions.map((s) => ({
-      ...s,
-      ratingKey: s.ratingKey || s.key?.split('/').pop() || '',
-    }))
+    // MyShows tracks shows/movies only. Plex `/status/sessions` also surfaces
+    // music (`track`), trailers/extras (`clip`) and photos — drop anything that
+    // isn't a movie or episode so a played track never scrobbles as an episode.
+    return sessions
+      .filter((s) => isScrobblableType((s as { type?: string }).type))
+      .map((s) => ({
+        ...s,
+        ratingKey: s.ratingKey || s.key?.split('/').pop() || '',
+      }))
   }
 
   private async fetchMetadataWithRating(ratingKey: string): Promise<{

--- a/src/adapters/vlc-http.ts
+++ b/src/adapters/vlc-http.ts
@@ -288,6 +288,14 @@ export function buildEvent(
     return null
   }
 
+  // For a song VLC reports an audio stream and no video. We only drop when
+  // audio is present and video is absent, so a video whose resolution VLC
+  // didn't parse isn't mistaken for music. VLC gives only a basename (no path),
+  // so we can't fall back to an ffprobe check here.
+  if (snapshot.audio != null && snapshot.video == null) {
+    return null
+  }
+
   const parsed = parseFilename(snapshot.filename)
   const state: PlaybackState = snapshot.state === 'paused' ? 'paused' : 'playing'
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,13 +27,26 @@ export const DEFAULT_MYSHOWS_URL = 'https://myshows.me/scrobble'
 export const DEFAULT_SOURCE_POLL_INTERVAL = 15000
 export const SERVICE_REQUEST_TIMEOUT_MS = 5000
 
+export const DEFAULT_MIN_DURATION_MINUTES = 5
+export const DEFAULT_STOP_AT_THRESHOLD = true
+
 const DEFAULT_CONFIG: AppConfig = {
   myshowsToken: '',
   myshowsUrl: DEFAULT_MYSHOWS_URL,
   scrobblePercent: 80,
+  minDurationMinutes: DEFAULT_MIN_DURATION_MINUTES,
+  stopAtThreshold: DEFAULT_STOP_AT_THRESHOLD,
   logLevel: 'info',
   interceptOnly: false,
   sources: [],
+}
+
+/** Coerce a possibly-garbage `min_duration_minutes` value to a sane number. */
+function normalizeMinDuration(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    return DEFAULT_MIN_DURATION_MINUTES
+  }
+  return value
 }
 
 const DEFAULT_SOURCE: Omit<SourceConfig, 'type'> = {
@@ -77,6 +90,11 @@ function rawToConfig(raw: RawConfig): AppConfig {
     myshowsToken: raw.myshows_token ?? '',
     myshowsUrl: raw.myshows_url ?? DEFAULT_MYSHOWS_URL,
     scrobblePercent: raw.scrobble_percent ?? DEFAULT_CONFIG.scrobblePercent,
+    minDurationMinutes: normalizeMinDuration(raw.min_duration_minutes),
+    stopAtThreshold:
+      typeof raw.stop_at_threshold === 'boolean'
+        ? raw.stop_at_threshold
+        : DEFAULT_CONFIG.stopAtThreshold,
     logLevel: (raw.log_level as LogLevel) ?? DEFAULT_CONFIG.logLevel,
     interceptOnly: raw.intercept_only ?? false,
     sources: (raw.sources ?? []).map(rawSourceToConfig),
@@ -88,6 +106,8 @@ function configToRaw(config: AppConfig): RawConfig {
     myshows_token: config.myshowsToken,
     ...(config.myshowsUrl ? { myshows_url: config.myshowsUrl } : {}),
     scrobble_percent: config.scrobblePercent,
+    min_duration_minutes: config.minDurationMinutes,
+    stop_at_threshold: config.stopAtThreshold,
     log_level: config.logLevel,
     intercept_only: config.interceptOnly,
     sources: config.sources.map(configSourceToRaw),
@@ -105,6 +125,8 @@ function migrateLegacy(data: LegacyConfig & Partial<RawConfig>): RawConfig {
     myshows_token: data.myshows_token ?? '',
     ...(data.myshows_url ? { myshows_url: data.myshows_url } : {}),
     scrobble_percent: data.scrobble_percent ?? DEFAULT_CONFIG.scrobblePercent,
+    min_duration_minutes: data.min_duration_minutes ?? DEFAULT_CONFIG.minDurationMinutes,
+    stop_at_threshold: data.stop_at_threshold ?? DEFAULT_CONFIG.stopAtThreshold,
     log_level: data.log_level ?? DEFAULT_CONFIG.logLevel,
     sources: [],
   }

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -262,7 +262,13 @@ export async function apiRoutes(fastify: FastifyInstance, ctx: ApiContext): Prom
     Body: Partial<
       Pick<
         AppConfig,
-        'interceptOnly' | 'scrobblePercent' | 'logLevel' | 'myshowsToken' | 'myshowsUrl'
+        | 'interceptOnly'
+        | 'scrobblePercent'
+        | 'minDurationMinutes'
+        | 'stopAtThreshold'
+        | 'logLevel'
+        | 'myshowsToken'
+        | 'myshowsUrl'
       >
     >
   }>('/api/config', async (request, reply) => {
@@ -284,6 +290,12 @@ export async function apiRoutes(fastify: FastifyInstance, ctx: ApiContext): Prom
     }
     if (body.scrobblePercent !== undefined) {
       next.scrobblePercent = body.scrobblePercent
+    }
+    if (body.minDurationMinutes !== undefined) {
+      next.minDurationMinutes = body.minDurationMinutes
+    }
+    if (body.stopAtThreshold !== undefined) {
+      next.stopAtThreshold = !!body.stopAtThreshold
     }
     if (body.logLevel !== undefined) {
       next.logLevel = body.logLevel

--- a/src/server.ts
+++ b/src/server.ts
@@ -145,6 +145,9 @@ export async function createServer(options: ServerOptions) {
   const lastBroadcastPercent = new Map<string, number>()
   // Track which sessions have sent SCROBBLE_START to MyShows.
   const startedSessions = new Set<string>()
+  // Sessions already finalized via the threshold rule (STOP sent at >= scrobblePercent
+  // during playback). Further events for these keys are ignored until the session ends.
+  const completedSessions = new Set<string>()
 
   // ── Helpers ──
 
@@ -198,7 +201,40 @@ export async function createServer(options: ServerOptions) {
     const percent = percentOf(event)
     const title = formatTitle(event)
 
+    const currentConfig = getConfig()
+
+    // Ignore very short media (clips, trailers, intros). `duration` is in ms
+    // across all adapters; unknown/zero durations can't be judged, so they pass.
+    const minDurationMs = Math.max(0, currentConfig.minDurationMinutes) * 60_000
+    if (
+      minDurationMs > 0 &&
+      event.duration != null &&
+      event.duration > 0 &&
+      event.duration < minDurationMs
+    ) {
+      // Duration can resolve late (e.g. SMTC/player sources report null first),
+      // so we may already be tracking this key — tear it down so a short clip
+      // never lingers on the now-playing board or leaves orphan state.
+      const wasTracked = nowPlaying.has(key)
+      untrack(key)
+      if (wasTracked) {
+        broadcastNowPlaying()
+      }
+      logger.debug(
+        `Ignored (too short): ${title} ` +
+          `(${(event.duration / 60_000).toFixed(1)}min < ${currentConfig.minDurationMinutes}min)`,
+      )
+      return { status: 'ignored', reason: 'too_short' }
+    }
+
+    const threshold = normalizedThreshold(currentConfig.scrobblePercent)
+
     if (event.action === 'progress') {
+      // Session already finalized at the threshold — stop tracking entirely.
+      if (completedSessions.has(key)) {
+        return { status: 'ignored', reason: 'already_scrobbled' }
+      }
+
       // Anti-spam: skip unless the percent actually moved.
       const last = lastBroadcastPercent.get(key)
       if (
@@ -212,6 +248,46 @@ export async function createServer(options: ServerOptions) {
         }
       }
       lastBroadcastPercent.set(key, percent)
+
+      // Crossed the threshold mid-playback (when enabled): send STOP now and
+      // stop tracking. If the STOP doesn't go through we don't commit — we fall
+      // back to the normal START/PAUSE flow and try again on the next tick that
+      // moves, so a network blip never loses the scrobble.
+      if (currentConfig.stopAtThreshold && percent >= threshold) {
+        // Make sure a START went out first — only matters in the rare case
+        // where the first tick we see is already past the threshold.
+        if (!startedSessions.has(key)) {
+          await sendToMyShows(
+            MYSHOWS_ENDPOINTS.SCROBBLE_START,
+            event,
+            percent,
+            title,
+            currentConfig,
+          )
+          startedSessions.add(key)
+        }
+
+        logger.info(`Completed at ${percent.toFixed(1)}%: ${title}`)
+        const stopped = await sendToMyShows(
+          MYSHOWS_ENDPOINTS.SCROBBLE_STOP,
+          event,
+          percent,
+          title,
+          currentConfig,
+        )
+
+        if (stopped) {
+          untrack(key)
+          completedSessions.add(key)
+          broadcastNowPlaying()
+          return { status: 'stopped' }
+        }
+
+        logger.warn(
+          `Stop at ${percent.toFixed(1)}% failed for ${title} — keeping session, will retry`,
+        )
+        // fall through to standard PAUSE tracking below
+      }
 
       nowPlaying.set(key, {
         key,
@@ -232,19 +308,21 @@ export async function createServer(options: ServerOptions) {
       logger.debug(`${endpoint}: ${title} [${event.state}] ${percent.toFixed(2)}%`)
 
       // Send to MyShows
-      await sendToMyShows(endpoint, event, percent, title)
+      await sendToMyShows(endpoint, event, percent, title, currentConfig)
 
       return { status: endpoint === MYSHOWS_ENDPOINTS.SCROBBLE_START ? 'started' : 'tracking' }
     }
 
     // action === 'stopped' — session ended.
-    nowPlaying.delete(key)
-    lastBroadcastPercent.delete(key)
-    startedSessions.delete(key)
+    const wasCompleted = completedSessions.has(key)
+    untrack(key)
     broadcastNowPlaying()
 
-    const currentConfig = getConfig()
-    const threshold = normalizedThreshold(currentConfig.scrobblePercent)
+    // Already finalized at the threshold during playback — don't STOP twice.
+    if (wasCompleted) {
+      return { status: 'ignored', reason: 'already_scrobbled' }
+    }
+
     const intercept = options.interceptOnly || currentConfig.interceptOnly
 
     if (percent < threshold) {
@@ -262,22 +340,27 @@ export async function createServer(options: ServerOptions) {
 
     logger.info(`Stopped: ${title} (${percent.toFixed(1)}%)`)
 
-    await sendToMyShows(MYSHOWS_ENDPOINTS.SCROBBLE_STOP, event, percent, title)
+    await sendToMyShows(MYSHOWS_ENDPOINTS.SCROBBLE_STOP, event, percent, title, currentConfig)
 
     return { status: 'stopped' }
   }
 
+  /**
+   * Send one scrobble request. Returns true when MyShows accepted it (or we're
+   * in intercept-only mode). A false result lets callers fall back / retry —
+   * the threshold STOP only "commits" on a true result.
+   */
   async function sendToMyShows(
     endpoint: ScrobbleEndpoint,
     event: NormalizedEvent,
     percent: number,
     title: string,
-  ): Promise<void> {
+    config: AppConfig,
+  ): Promise<boolean> {
     const payload = toScrobbleRequest(event, percent)
     logger.debug(`${endpoint} payload: ${JSON.stringify(payload)}`)
 
-    const currentConfig = getConfig()
-    const intercept = options.interceptOnly || currentConfig.interceptOnly
+    const intercept = options.interceptOnly || config.interceptOnly
 
     if (intercept) {
       logger.info(`[Intercept-only] ${endpoint}: ${title}`)
@@ -287,7 +370,7 @@ export async function createServer(options: ServerOptions) {
         status: 'success',
         intercept: true,
       })
-      return
+      return true
     }
 
     if (!myShowsClient.getToken()) {
@@ -299,7 +382,7 @@ export async function createServer(options: ServerOptions) {
         error: 'No token',
         intercept: false,
       })
-      return
+      return false
     }
 
     const result = await myShowsClient.sendScrobble(endpoint, payload)
@@ -317,6 +400,16 @@ export async function createServer(options: ServerOptions) {
     } else {
       logger.error(`${endpoint}: ${title} -> FAIL: ${result.error}`)
     }
+
+    return result.success
+  }
+
+  /** Drop all per-session tracking state for a content key. */
+  function untrack(key: string): void {
+    nowPlaying.delete(key)
+    lastBroadcastPercent.delete(key)
+    startedSessions.delete(key)
+    completedSessions.delete(key)
   }
 
   // ── Bootstrap adapters ──
@@ -327,6 +420,7 @@ export async function createServer(options: ServerOptions) {
     nowPlaying.clear()
     lastBroadcastPercent.clear()
     startedSessions.clear()
+    completedSessions.clear()
     broadcastNowPlaying()
 
     const currentConfig = getConfig()

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,14 @@ export interface AppConfig {
   myshowsToken: string
   myshowsUrl?: string
   scrobblePercent: number
+  /** Minimum media length (minutes) to track. Shorter videos are ignored. 0 disables the check. */
+  minDurationMinutes: number
+  /**
+   * When true, send the STOP scrobble as soon as `scrobblePercent` is reached
+   * and stop tracking the title. When false, STOP waits until playback actually
+   * ends (how it worked before this option existed).
+   */
+  stopAtThreshold: boolean
   logLevel: LogLevel
   interceptOnly: boolean
   sources: SourceConfig[]
@@ -133,6 +141,8 @@ export interface RawConfig {
   myshows_token: string
   myshows_url?: string
   scrobble_percent: number
+  min_duration_minutes?: number
+  stop_at_threshold?: boolean
   log_level: string
   intercept_only?: boolean
   sources: RawSourceConfig[]

--- a/src/utils/media-duration.ts
+++ b/src/utils/media-duration.ts
@@ -177,6 +177,16 @@ export interface FileMediaProbe {
   video: FileVideoInfo | null
 }
 
+/**
+ * True when a probe positively shows audio but no real video stream — i.e. a
+ * music file. Cover art is already excluded upstream (attached-picture streams
+ * are skipped), so `video == null` here means "no actual video track". A null
+ * probe (no path / no tool) is "unknown", not music.
+ */
+export function isProbedAudioOnly(probe: FileMediaProbe | null): boolean {
+  return probe != null && probe.video == null && probe.audio != null
+}
+
 interface FfprobeStream {
   codec_type?: string
   codec_name?: string
@@ -184,7 +194,7 @@ interface FfprobeStream {
   width?: number
   height?: number
   color_transfer?: string
-  disposition?: { default?: number }
+  disposition?: { default?: number; attached_pic?: number }
   tags?: Record<string, string>
   side_data_list?: Array<{ side_data_type?: string }>
 }
@@ -220,7 +230,12 @@ async function probeViaFfprobe(bin: string, filePath: string): Promise<FileMedia
       }
     : null
 
-  const videoStream = streams.find((s) => s.codec_type === 'video')
+  // Ignore attached-picture streams (cover art embedded in music files) — they
+  // are video codecs but not a real video track, so a song must not register
+  // as having video.
+  const videoStream = streams.find(
+    (s) => s.codec_type === 'video' && s.disposition?.attached_pic !== 1,
+  )
   const video: FileVideoInfo | null = videoStream
     ? {
         width: typeof videoStream.width === 'number' ? videoStream.width : null,
@@ -273,6 +288,8 @@ async function probeViaMediainfo(bin: string, filePath: string): Promise<FileMed
       }
     : null
 
+  // No attached-picture filter needed here: mediainfo reports embedded cover
+  // art as an "Image" track, not "Video", so a song never matches this.
   const videoTrack = tracks.find((t) => t['@type'] === 'Video')
   const video: FileVideoInfo | null = videoTrack
     ? {

--- a/src/utils/mpv-ipc.ts
+++ b/src/utils/mpv-ipc.ts
@@ -43,6 +43,9 @@ const MPV_PROPS = [
   'video-params/h',
   'video-params/gamma',
   'current-tracks/video/dolby-vision-profile',
+  // True when the selected "video" track is just embedded cover art (music
+  // file). Lets us tell a song-with-artwork apart from a real video.
+  'current-tracks/video/albumart',
   // mpv build version, e.g. "mpv v0.41.0-…". Always available.
   'mpv-version',
 ] as const
@@ -76,6 +79,8 @@ export interface MpvProperties {
   videoGamma: string | null
   /** Dolby Vision profile number of the selected video track, when present. */
   doviProfile: number | null
+  /** True when the selected video track is embedded cover art (music file). */
+  videoAlbumart: boolean | null
   /** mpv version string ("mpv v0.41.0" or "v0.41.0" depending on build). */
   mpvVersion: string | null
 }
@@ -100,6 +105,7 @@ function mapResults(raw: Record<string, unknown>): MpvProperties {
     videoHeight: num(raw['video-params/h']),
     videoGamma: str(raw['video-params/gamma']),
     doviProfile: num(raw['current-tracks/video/dolby-vision-profile']),
+    videoAlbumart: bool(raw['current-tracks/video/albumart']),
     mpvVersion: str(raw['mpv-version']),
   }
 }

--- a/src/utils/windows-smtc.ts
+++ b/src/utils/windows-smtc.ts
@@ -27,6 +27,13 @@ export interface SmtcPlayback {
    * step can opt in per-player without touching the probe again.
    */
   albumTitle: string
+  /**
+   * Media kind the app reports: "Music" | "Video" | "Image" | "Unknown" | "".
+   * Optional/empty when the app doesn't publish it or a packaged build still
+   * ships the older probe script. Used to drop songs/photos without guessing
+   * from the app id.
+   */
+  playbackType?: string
   isPlaying: boolean
   positionSeconds: number
   durationSeconds: number
@@ -106,6 +113,7 @@ export function isSmtcPlayback(value: unknown): value is SmtcPlayback {
     typeof v.title === 'string' &&
     typeof v.artist === 'string' &&
     typeof v.albumTitle === 'string' &&
+    (v.playbackType === undefined || typeof v.playbackType === 'string') &&
     typeof v.isPlaying === 'boolean' &&
     typeof v.positionSeconds === 'number' &&
     typeof v.durationSeconds === 'number'

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -12,6 +12,8 @@ const baseConfig: AppConfig = {
   myshowsToken: '',
   myshowsUrl: 'https://myshows.me/scrobble',
   scrobblePercent: 80,
+  minDurationMinutes: 5,
+  stopAtThreshold: true,
   logLevel: 'info',
   interceptOnly: false,
   sources: [],

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -22,6 +22,8 @@ describe('readConfig / writeConfig', () => {
     const cfg = readConfig()
     expect(cfg.myshowsUrl).toBe('https://myshows.me/scrobble')
     expect(cfg.scrobblePercent).toBe(80)
+    expect(cfg.minDurationMinutes).toBe(5)
+    expect(cfg.stopAtThreshold).toBe(true)
     expect(cfg.logLevel).toBe('info')
     expect(cfg.interceptOnly).toBe(false)
     expect(cfg.sources).toEqual([])
@@ -33,6 +35,8 @@ describe('readConfig / writeConfig', () => {
       myshowsToken: 'tok',
       myshowsUrl: 'https://example.test/api',
       scrobblePercent: 70,
+      minDurationMinutes: 3,
+      stopAtThreshold: false,
       logLevel: 'debug',
       interceptOnly: true,
       sources: [
@@ -51,6 +55,8 @@ describe('readConfig / writeConfig', () => {
     expect(raw.myshows_token).toBe('tok')
     expect(raw.intercept_only).toBe(true)
     expect(raw.scrobble_percent).toBe(70)
+    expect(raw.min_duration_minutes).toBe(3)
+    expect(raw.stop_at_threshold).toBe(false)
     expect(raw.sources[0].url).toBe('http://plex:32400')
     expect(raw.sources[0].poll_interval).toBe(1234)
     expect(raw.sources[0].user_filter).toEqual(['alice'])
@@ -58,6 +64,8 @@ describe('readConfig / writeConfig', () => {
 
     const cfg = readConfig()
     expect(cfg.interceptOnly).toBe(true)
+    expect(cfg.minDurationMinutes).toBe(3)
+    expect(cfg.stopAtThreshold).toBe(false)
     expect(cfg.sources[0].url).toBe('http://plex:32400')
     expect(cfg.sources[0].pollInterval).toBe(1234)
     expect(cfg.sources[0].userFilter).toEqual(['alice'])
@@ -89,6 +97,41 @@ describe('readConfig / writeConfig', () => {
     expect(cfg.sources).toHaveLength(1)
     expect(cfg.sources[0]).not.toHaveProperty('mode')
     expect(cfg.sources[0].type).toBe('plex')
+  })
+
+  it('falls back to defaults for invalid min_duration_minutes / stop_at_threshold', () => {
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        myshows_token: 'tok',
+        myshows_url: 'https://example.test/api',
+        scrobble_percent: 80,
+        min_duration_minutes: 'garbage',
+        stop_at_threshold: 'yes',
+        log_level: 'info',
+        sources: [],
+      }),
+    )
+
+    const cfg = readConfig()
+    expect(cfg.minDurationMinutes).toBe(5)
+    expect(cfg.stopAtThreshold).toBe(true)
+  })
+
+  it('accepts 0 as a valid (disabling) min_duration_minutes', () => {
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        myshows_token: 'tok',
+        myshows_url: 'https://example.test/api',
+        scrobble_percent: 80,
+        min_duration_minutes: 0,
+        log_level: 'info',
+        sources: [],
+      }),
+    )
+
+    expect(readConfig().minDurationMinutes).toBe(0)
   })
 
   it('uses 15 seconds as the default source polling interval', () => {

--- a/tests/unit/iina-ipc.test.ts
+++ b/tests/unit/iina-ipc.test.ts
@@ -86,10 +86,11 @@ describe('buildEvent source attribution', () => {
     audioTitle: null,
     audioCodec: null,
     audioChannelCount: null,
-    videoWidth: null,
-    videoHeight: null,
+    videoWidth: 1920,
+    videoHeight: 1080,
     videoGamma: null,
     doviProfile: null,
+    videoAlbumart: null,
     mpvVersion: null,
   }
 

--- a/tests/unit/jellyfin.test.ts
+++ b/tests/unit/jellyfin.test.ts
@@ -137,6 +137,41 @@ describe('JellyfinAdapter polling diff', () => {
     })
   })
 
+  it('ignores music (Audio) and other non-video item types', async () => {
+    const emitted: NormalizedEvent[] = []
+    const adapter = new JellyfinAdapter(makeConfig('jellyfin'), {
+      onScrobble: async (e) => {
+        emitted.push(e)
+      },
+      onLog: () => {},
+    })
+    ;(adapter as unknown as { running: boolean }).running = true
+
+    const audioSession = {
+      Id: 'sess-audio',
+      UserId: 'user1',
+      PlayState: { PositionTicks: 100_000_000, IsPaused: false },
+      NowPlayingItem: {
+        Id: 'track-1',
+        Name: 'Some Song',
+        Type: 'Audio',
+        RunTimeTicks: 2_000_000_000,
+      },
+    }
+
+    vi.stubGlobal(
+      'fetch',
+      routedFetch({
+        '/Sessions': () => sessionsResponse([audioSession]),
+        '/Items/track-1': () => itemResponse(audioSession.NowPlayingItem),
+      }),
+    )
+
+    await tick(adapter)
+
+    expect(emitted).toHaveLength(0)
+  })
+
   it('emits a stopped event when the session disappears', async () => {
     const emitted: NormalizedEvent[] = []
     const adapter = new JellyfinAdapter(makeConfig('jellyfin'), {

--- a/tests/unit/kodi.test.ts
+++ b/tests/unit/kodi.test.ts
@@ -100,6 +100,25 @@ describe('KodiAdapter polling diff', () => {
     })
   })
 
+  it('ignores a musicvideo playing in the video player', async () => {
+    const emitted: NormalizedEvent[] = []
+    const adapter = makeAdapter(emitted)
+    ;(adapter as unknown as { running: boolean }).running = true
+
+    fetchMock
+      .mockResolvedValueOnce(rpcResponse([{ playerid: 1, playertype: 'internal', type: 'video' }]))
+      .mockResolvedValueOnce(
+        rpcResponse({ item: { ...movieItem, type: 'musicvideo', label: 'Some Clip' } }),
+      )
+      .mockResolvedValueOnce(
+        rpcResponse({ time: timeAt(30), totaltime: timeAt(200), percentage: 15, speed: 1 }),
+      )
+
+    await tick(adapter)
+
+    expect(emitted).toHaveLength(0)
+  })
+
   it('enriches progress from Kodi item metadata', async () => {
     const emitted: NormalizedEvent[] = []
     const adapter = makeAdapter(emitted)

--- a/tests/unit/mpc-http.test.ts
+++ b/tests/unit/mpc-http.test.ts
@@ -108,6 +108,15 @@ describe('buildEvent', () => {
     expect(event?.dubTeam).toBe('Велес')
   })
 
+  it('returns null when the probe shows audio but no video stream (music)', () => {
+    const snapshot = snapshotFromVariables(parseMpcVariables(SAMPLE_HTML))
+    const event = buildEvent(snapshot, 'progress', {
+      audio: { language: null, title: null, codec: 'flac', channels: 2 },
+      video: null,
+    })
+    expect(event).toBeNull()
+  })
+
   it('reports dolby_vision when the probe carries a DV configuration record', () => {
     const snapshot = snapshotFromVariables(parseMpcVariables(SAMPLE_HTML))
     const event = buildEvent(snapshot, 'progress', {

--- a/tests/unit/mpv-ipc.test.ts
+++ b/tests/unit/mpv-ipc.test.ts
@@ -134,10 +134,11 @@ describe('buildEvent', () => {
     audioTitle: null,
     audioCodec: null,
     audioChannelCount: null,
-    videoWidth: null,
-    videoHeight: null,
+    videoWidth: 1920,
+    videoHeight: 1080,
     videoGamma: null,
     doviProfile: null,
+    videoAlbumart: null,
     mpvVersion: null,
   }
 
@@ -180,8 +181,35 @@ describe('buildEvent', () => {
         videoHeight: null,
         videoGamma: null,
         doviProfile: null,
+        videoAlbumart: null,
         mpvVersion: null,
       },
+      'progress',
+    )
+    expect(event).toBeNull()
+  })
+
+  it('returns null for an audio-only file (music)', () => {
+    const event = buildEvent(
+      {
+        ...base,
+        path: 'D:\\Music\\Pink.Floyd.-.Time.flac',
+        mediaTitle: 'Time',
+        videoWidth: null,
+        videoHeight: null,
+        videoGamma: null,
+        doviProfile: null,
+        audioCodec: 'flac',
+        audioChannelCount: 2,
+      },
+      'progress',
+    )
+    expect(event).toBeNull()
+  })
+
+  it('returns null for a song whose only video track is cover art', () => {
+    const event = buildEvent(
+      { ...base, audioCodec: 'mp3', videoWidth: 600, videoHeight: 600, videoAlbumart: true },
       'progress',
     )
     expect(event).toBeNull()

--- a/tests/unit/player.test.ts
+++ b/tests/unit/player.test.ts
@@ -37,6 +37,9 @@ describe('PlayerAdapter', () => {
       source: 'system',
     })
     vi.spyOn(mediaDuration, 'getMediaDurationSeconds').mockResolvedValue(2700)
+    // Default: no container probe (real files under test don't exist on disk).
+    // Individual tests override to exercise the audio-only music guard.
+    vi.spyOn(mediaDuration, 'probeFileMedia').mockResolvedValue(null)
     // Default: no precise readings. Individual tests override per-call to
     // exercise the macOS/MPRIS/SMTC override path. All three probes must be
     // mocked, otherwise the test runner on a real OS would hit the live
@@ -97,6 +100,66 @@ describe('PlayerAdapter', () => {
 
     expect(emitted).toHaveLength(2)
     expect(emitted[1]).toMatchObject({ source: 'player', action: 'stopped' })
+  })
+
+  it('does not scrobble an audio-only file (music) detected via process scan', async () => {
+    const emitted: NormalizedEvent[] = []
+    const adapter = makeAdapter(emitted)
+    ;(adapter as unknown as { running: boolean }).running = true
+
+    // ffprobe reports an audio track and no real video stream → it's a song.
+    vi.spyOn(mediaDuration, 'probeFileMedia').mockResolvedValue({
+      audio: { language: null, title: null, codec: 'flac', channels: 2 },
+      video: null,
+    })
+
+    const scan = vi.spyOn(processMonitor, 'scanPlayers')
+    scan.mockResolvedValue({
+      processes: [
+        {
+          pid: 4242,
+          player: 'vlc',
+          startedAt: new Date(Date.now() - 30_000),
+          commandLine: 'vlc /Users/me/Music/Pink.Floyd.-.Time.flac',
+        },
+      ],
+    })
+
+    await tick(adapter)
+    await tick(adapter)
+
+    expect(emitted).toHaveLength(0)
+  })
+
+  it('probes a music file once and does not recreate the session each tick', async () => {
+    const emitted: NormalizedEvent[] = []
+    const adapter = makeAdapter(emitted)
+    ;(adapter as unknown as { running: boolean }).running = true
+
+    const probeSpy = vi.spyOn(mediaDuration, 'probeFileMedia').mockResolvedValue({
+      audio: { language: null, title: null, codec: 'flac', channels: 2 },
+      video: null,
+    })
+
+    vi.spyOn(processMonitor, 'scanPlayers').mockResolvedValue({
+      processes: [
+        {
+          pid: 4242,
+          player: 'vlc',
+          startedAt: new Date(Date.now() - 30_000),
+          commandLine: 'vlc /Users/me/Music/song.flac',
+        },
+      ],
+    })
+
+    await tick(adapter)
+    await tick(adapter)
+    await tick(adapter)
+
+    expect(emitted).toHaveLength(0)
+    // Identified as music on the first tick; later ticks short-circuit before
+    // the session is recreated, so no repeated probe (or "Detected" log spam).
+    expect(probeSpy).toHaveBeenCalledTimes(1)
   })
 
   it('does not emit stop after a single missed tick (lsof flicker tolerance)', async () => {
@@ -713,6 +776,31 @@ describe('PlayerAdapter', () => {
           isPlaying: true,
           positionSeconds: 30,
           durationSeconds: 200,
+        },
+      ])
+
+      await tick(adapter)
+
+      expect(emitted).toHaveLength(0)
+    })
+
+    it('skips SMTC sessions whose PlaybackType is Music (any app)', async () => {
+      const emitted: NormalizedEvent[] = []
+      const adapter = makeAdapter(emitted)
+      ;(adapter as unknown as { running: boolean }).running = true
+
+      vi.spyOn(processMonitor, 'scanPlayers').mockResolvedValueOnce({ processes: [] })
+      vi.spyOn(windowsSmtc, 'probeWindowsSmtc').mockResolvedValueOnce([
+        {
+          // A generic music app not on the by-name skip list.
+          appUserModelId: 'foobar2000.exe',
+          title: 'Time',
+          artist: 'Pink Floyd',
+          albumTitle: 'The Dark Side of the Moon',
+          playbackType: 'Music',
+          isPlaying: true,
+          positionSeconds: 60,
+          durationSeconds: 413,
         },
       ])
 

--- a/tests/unit/plex.test.ts
+++ b/tests/unit/plex.test.ts
@@ -110,6 +110,31 @@ describe('PlexAdapter polling diff', () => {
     })
   })
 
+  it('ignores non-video sessions (music track, clip, photo)', async () => {
+    const emitted: NormalizedEvent[] = []
+    const adapter = makeAdapter(emitted)
+    ;(adapter as unknown as { running: boolean }).running = true
+
+    const trackSession = {
+      ...episodeSession,
+      sessionKey: 'music1',
+      type: 'track',
+      title: 'Some Song',
+      grandparentTitle: 'Some Artist',
+    }
+
+    vi.stubGlobal(
+      'fetch',
+      routedFetch({
+        '/status/sessions': () => sessionsResponse([trackSession]),
+      }),
+    )
+
+    await tick(adapter)
+
+    expect(emitted).toHaveLength(0)
+  })
+
   it('emits another progress when viewOffset advances', async () => {
     const emitted: NormalizedEvent[] = []
     const adapter = makeAdapter(emitted)

--- a/tests/unit/server.scrobble.test.ts
+++ b/tests/unit/server.scrobble.test.ts
@@ -355,4 +355,229 @@ describe('handleScrobble pipeline', () => {
 
     await fastify.close()
   })
+
+  it('progress crossing scrobblePercent sends STOP, then stops tracking the title', async () => {
+    const server = await buildServer({
+      sources: [
+        {
+          type: 'plex',
+          enabled: true,
+          url: 'http://x',
+          token: 't',
+          poll_interval: 5000,
+          user_filter: [],
+        },
+      ],
+    })
+    const { fastify } = server
+    const spy = mockSendScrobble(server)
+
+    await emitVia(server, sampleEpisode({ viewOffset: 282000 })) // 10% → START
+    expect(spy.mock.calls[0][0]).toBe(MYSHOWS_ENDPOINTS.SCROBBLE_START)
+
+    await emitVia(server, sampleEpisode({ viewOffset: 2540000 })) // ~90% → STOP
+    expect(spy).toHaveBeenCalledTimes(2)
+    expect(spy.mock.calls[1][0]).toBe(MYSHOWS_ENDPOINTS.SCROBBLE_STOP)
+
+    // Title is no longer tracked.
+    const nowRes = await fastify.inject({ method: 'GET', url: '/api/now-playing' })
+    expect(JSON.parse(nowRes.payload).nowPlaying).toHaveLength(0)
+
+    // Further progress ticks are ignored (no PAUSE spam).
+    await emitVia(server, sampleEpisode({ viewOffset: 2679000 })) // ~95%
+    expect(spy).toHaveBeenCalledTimes(2)
+
+    // The eventual stopped event does not re-send STOP.
+    await emitVia(server, sampleEpisode({ action: 'stopped', viewOffset: 2679000 }))
+    expect(spy).toHaveBeenCalledTimes(2)
+
+    await fastify.close()
+  })
+
+  it('first observed tick already past threshold sends START then STOP', async () => {
+    const server = await buildServer({
+      sources: [
+        {
+          type: 'plex',
+          enabled: true,
+          url: 'http://x',
+          token: 't',
+          poll_interval: 5000,
+          user_filter: [],
+        },
+      ],
+    })
+    const { fastify } = server
+    const spy = mockSendScrobble(server)
+
+    await emitVia(server, sampleEpisode({ viewOffset: 2679000 })) // ~95%, never started
+    expect(spy).toHaveBeenCalledTimes(2)
+    expect(spy.mock.calls[0][0]).toBe(MYSHOWS_ENDPOINTS.SCROBBLE_START)
+    expect(spy.mock.calls[1][0]).toBe(MYSHOWS_ENDPOINTS.SCROBBLE_STOP)
+
+    await fastify.close()
+  })
+
+  it('videos shorter than minDurationMinutes are ignored entirely', async () => {
+    const server = await buildServer({
+      sources: [
+        {
+          type: 'plex',
+          enabled: true,
+          url: 'http://x',
+          token: 't',
+          poll_interval: 5000,
+          user_filter: [],
+        },
+      ],
+    })
+    const { fastify } = server
+    const spy = mockSendScrobble(server)
+
+    const shortClip = { duration: 120000 } // 2 min, below the 5 min default
+
+    await emitVia(server, sampleEpisode({ ...shortClip, viewOffset: 60000 })) // 50% progress
+    await emitVia(server, sampleEpisode({ ...shortClip, action: 'stopped', viewOffset: 108000 })) // 90%
+
+    expect(spy).not.toHaveBeenCalled()
+
+    const nowRes = await fastify.inject({ method: 'GET', url: '/api/now-playing' })
+    expect(JSON.parse(nowRes.payload).nowPlaying).toHaveLength(0)
+
+    const evRes = await fastify.inject({ method: 'GET', url: '/api/events' })
+    expect(JSON.parse(evRes.payload).events).toHaveLength(0)
+
+    await fastify.close()
+  })
+
+  it('stopAtThreshold=false keeps tracking past the threshold (STOP only on stop)', async () => {
+    const server = await buildServer({
+      stop_at_threshold: false,
+      sources: [
+        {
+          type: 'plex',
+          enabled: true,
+          url: 'http://x',
+          token: 't',
+          poll_interval: 5000,
+          user_filter: [],
+        },
+      ],
+    })
+    const { fastify } = server
+    const spy = mockSendScrobble(server)
+
+    await emitVia(server, sampleEpisode({ viewOffset: 282000 })) // 10% → START
+    await emitVia(server, sampleEpisode({ viewOffset: 2540000 })) // ~90% → PAUSE, not STOP
+    expect(spy).toHaveBeenCalledTimes(2)
+    expect(spy.mock.calls[1][0]).toBe(MYSHOWS_ENDPOINTS.SCROBBLE_PAUSE)
+
+    // Still tracked.
+    const nowRes = await fastify.inject({ method: 'GET', url: '/api/now-playing' })
+    expect(JSON.parse(nowRes.payload).nowPlaying).toHaveLength(1)
+
+    // STOP only fires when playback actually ends.
+    await emitVia(server, sampleEpisode({ action: 'stopped', viewOffset: 2540000 }))
+    expect(spy).toHaveBeenCalledTimes(3)
+    expect(spy.mock.calls[2][0]).toBe(MYSHOWS_ENDPOINTS.SCROBBLE_STOP)
+
+    await fastify.close()
+  })
+
+  it('failed STOP at threshold falls back to PAUSE and retries on the next tick', async () => {
+    const server = await buildServer({
+      sources: [
+        {
+          type: 'plex',
+          enabled: true,
+          url: 'http://x',
+          token: 't',
+          poll_interval: 5000,
+          user_filter: [],
+        },
+      ],
+    })
+    const { fastify } = server
+    const spy = vi
+      .spyOn(server.myShowsClient, 'sendScrobble')
+      .mockResolvedValueOnce({ success: true }) // START @10%
+      .mockResolvedValueOnce({ success: false, error: 'network' }) // STOP @90% fails
+      .mockResolvedValue({ success: true }) // PAUSE @90%, then STOP @95%
+
+    await emitVia(server, sampleEpisode({ viewOffset: 282000 })) // 10% → START
+    await emitVia(server, sampleEpisode({ viewOffset: 2540000 })) // ~90% → STOP(fail) → PAUSE
+
+    expect(spy.mock.calls[1][0]).toBe(MYSHOWS_ENDPOINTS.SCROBBLE_STOP)
+    expect(spy.mock.calls[2][0]).toBe(MYSHOWS_ENDPOINTS.SCROBBLE_PAUSE)
+
+    // Not finalized — still tracked.
+    let nowRes = await fastify.inject({ method: 'GET', url: '/api/now-playing' })
+    expect(JSON.parse(nowRes.payload).nowPlaying).toHaveLength(1)
+
+    // Next changed tick retries STOP, which now succeeds → finalized.
+    await emitVia(server, sampleEpisode({ viewOffset: 2679000 })) // ~95% → STOP(ok)
+    expect(spy.mock.calls[3][0]).toBe(MYSHOWS_ENDPOINTS.SCROBBLE_STOP)
+    expect(spy).toHaveBeenCalledTimes(4)
+
+    nowRes = await fastify.inject({ method: 'GET', url: '/api/now-playing' })
+    expect(JSON.parse(nowRes.payload).nowPlaying).toHaveLength(0)
+
+    await fastify.close()
+  })
+
+  it('cleans up now-playing when duration resolves late to under the minimum', async () => {
+    const server = await buildServer({
+      sources: [
+        {
+          type: 'plex',
+          enabled: true,
+          url: 'http://x',
+          token: 't',
+          poll_interval: 5000,
+          user_filter: [],
+        },
+      ],
+    })
+    const { fastify } = server
+    const spy = mockSendScrobble(server)
+
+    // Duration unknown on the first tick → tracked.
+    await emitVia(server, sampleEpisode({ duration: null, viewOffset: 0 }))
+    let nowRes = await fastify.inject({ method: 'GET', url: '/api/now-playing' })
+    expect(JSON.parse(nowRes.payload).nowPlaying).toHaveLength(1)
+
+    // Duration resolves to a 2 min clip → key is torn down, board cleared.
+    await emitVia(server, sampleEpisode({ duration: 120000, viewOffset: 60000 }))
+    nowRes = await fastify.inject({ method: 'GET', url: '/api/now-playing' })
+    expect(JSON.parse(nowRes.payload).nowPlaying).toHaveLength(0)
+
+    // Only the first (unknown-duration) tick produced a call; the short one didn't.
+    expect(spy).toHaveBeenCalledTimes(1)
+
+    await fastify.close()
+  })
+
+  it('minDurationMinutes=0 disables the short-video skip', async () => {
+    const server = await buildServer({
+      min_duration_minutes: 0,
+      sources: [
+        {
+          type: 'plex',
+          enabled: true,
+          url: 'http://x',
+          token: 't',
+          poll_interval: 5000,
+          user_filter: [],
+        },
+      ],
+    })
+    const { fastify } = server
+    const spy = mockSendScrobble(server)
+
+    await emitVia(server, sampleEpisode({ duration: 120000, viewOffset: 12000 })) // 2 min clip, 10%
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.calls[0][0]).toBe(MYSHOWS_ENDPOINTS.SCROBBLE_START)
+
+    await fastify.close()
+  })
 })

--- a/tests/unit/vlc-http.test.ts
+++ b/tests/unit/vlc-http.test.ts
@@ -156,6 +156,22 @@ describe('buildEvent', () => {
     expect(event?.title?.toLowerCase()).toContain('breaking')
   })
 
+  it('returns null for an audio-only file (music)', () => {
+    const event = buildEvent(
+      {
+        state: 'playing',
+        positionMs: 60_000,
+        durationMs: 200_000,
+        filename: 'Pink Floyd - Time.flac',
+        version: null,
+        audio: { language: null, description: null, codec: 'flac', channels: 2 },
+        video: null,
+      },
+      'progress',
+    )
+    expect(event).toBeNull()
+  })
+
   it('returns null when filename is empty', () => {
     const event = buildEvent(
       { state: 'stopped', positionMs: 0, durationMs: 0, filename: '', version: null },

--- a/tests/unit/windows-smtc.test.ts
+++ b/tests/unit/windows-smtc.test.ts
@@ -63,6 +63,15 @@ describe('isSmtcPlayback', () => {
     expect(isSmtcPlayback({ ...validPayload, albumTitle: 42 })).toBe(false)
     expect(isSmtcPlayback({ ...validPayload, albumTitle: null })).toBe(false)
   })
+
+  it('accepts the optional playbackType field but tolerates its absence', () => {
+    // Present (current probe).
+    expect(isSmtcPlayback({ ...validPayload, playbackType: 'Music' })).toBe(true)
+    // Absent (older packaged probe script) — still valid.
+    expect(isSmtcPlayback(validPayload)).toBe(true)
+    // Wrong type is rejected.
+    expect(isSmtcPlayback({ ...validPayload, playbackType: 2 })).toBe(false)
+  })
 })
 
 describe('SMTC_SKIP_PLAYERS', () => {

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -47,6 +47,14 @@ export interface AppConfig {
   myshowsToken: string
   myshowsUrl?: string
   scrobblePercent: number
+  /** Minimum media length (minutes) to track. Shorter videos are ignored. 0 disables the check. */
+  minDurationMinutes: number
+  /**
+   * When true, fire SCROBBLE_STOP as soon as `scrobblePercent` is reached during
+   * playback and stop tracking the title. When false, STOP is only sent when
+   * playback actually ends (the pre-feature behavior).
+   */
+  stopAtThreshold: boolean
   logLevel: LogLevel
   interceptOnly: boolean
   sources: SourceConfig[]
@@ -127,6 +135,13 @@ export interface NormalizedEvent {
   duration: number | null
   viewOffset: number | null
   source: SourceType
+  /**
+   * What to report to MyShows as `source_app` when it should be more specific
+   * than `source`. The generic `player` source uses this to name the actual
+   * player ("potplayer", "wmp") while `source` stays 'player' for routing,
+   * exclusions and session keys. Converter falls back to `source` when unset.
+   */
+  sourceApp?: string | null
   action: PlaybackAction
   state: PlaybackState
   /** Player app version (e.g. "5.94.1") */


### PR DESCRIPTION
…t music

Scrobble lifecycle (server.ts, config.ts):
- skip media shorter than `minDurationMinutes` (default 5) so trailers, intros and clips never scrobble; 0 disables the check. Duration is read in ms across all adapters; unknown/zero durations still pass.
- new `stopAtThreshold` toggle (default on): send STOP as soon as `scrobblePercent` is reached mid-playback and stop tracking the title, instead of waiting for playback to actually end. Off restores the old behavior.
- the threshold STOP only commits on success — a failed send falls back to the normal START/PAUSE flow and retries on the next tick that moves, so a network blip never loses the scrobble.
- harden config: coerce a garbage `min_duration_minutes` back to the default, default `stop_at_threshold` to true; expose both via PATCH /api/config.

Music filtering (all sources — MyShows tracks shows/movies, not songs):
- servers: drop sessions that aren't movie/episode (Plex `track`/`clip`/`photo`, Jellyfin/Emby `Audio`/`MusicVideo`, Kodi `musicvideo` in the video player), using each source's own content type.
- local players: only scrobble when there's a real video stream — mpc/mpv/iina via the container probe / mpv params, vlc via its stream info. Embedded cover art (attached_pic) is excluded so a song with artwork isn't seen as video.
- generic player adapter: drop audio-only files via the ffprobe gate, plus SMTC PlaybackType=Music/Image and known MPRIS music players (rhythmbox). A music session is retired once, not re-probed and re-logged every poll.

Cleanup:
- share one `isScrobblableType` (media-info) across the four server adapters and one `isProbedAudioOnly` (media-duration) across player/mpc.
- factor the per-session teardown into `untrack` (server) and `retireSession` (player); pass the resolved config into `sendToMyShows` to avoid a second config read per sending tick.