### PR TITLE
Honour user_filter for Jellyfin and Emby (fixes #30)

### DIFF
--- a/src/adapters/jellyfin.ts
+++ b/src/adapters/jellyfin.ts
@@ -82,6 +82,28 @@ export interface JellyfinSession {
 
 // ── Helpers ──
 
+/**
+ * Hidden per-user filter (config-only `user_filter`). Empty = every viewer counts;
+ * otherwise a session counts only if its `UserId` or `UserName` matches an entry
+ * (trimmed, case-insensitive). A session with no user info is dropped when a filter is set.
+ * Mirrors matchesUserFilter in adapters/plex.ts.
+ */
+export function matchesUserFilter(
+  user: { id?: string; title?: string } | undefined,
+  filter: string[],
+): boolean {
+  const wanted = filter.map((v) => v.trim().toLowerCase()).filter((v) => v.length > 0)
+  if (wanted.length === 0) {
+    return true
+  }
+  if (!user) {
+    return false
+  }
+  const id = user.id?.trim().toLowerCase()
+  const title = user.title?.trim().toLowerCase()
+  return (!!id && wanted.includes(id)) || (!!title && wanted.includes(title))
+}
+
 function normalizeType(type?: string): 'movie' | 'episode' {
   if (type?.toLowerCase() === 'episode') {
     return 'episode'
@@ -283,7 +305,12 @@ export class JellyfinAdapter extends BaseAdapter {
     }
 
     try {
-      const sessions = await this.fetchSessions()
+      // Apply the hidden `user_filter` here (not in fetchSessions) so both the Jellyfin and
+      // the Emby adapter get it from one place — Emby overrides fetchSessions and would
+      // otherwise silently skip the filter.
+      const sessions = (await this.fetchSessions()).filter((s) =>
+        matchesUserFilter({ id: s.UserId, title: s.UserName }, this.config.userFilter),
+      )
       const currentIds = new Set(sessions.map((s) => s.Id))
       const nextPrevious = new Map<string, JellyfinSession>()
 
@@ -347,6 +374,7 @@ export class JellyfinAdapter extends BaseAdapter {
     }
 
     const sessions = (await response.json()) as JellyfinSession[]
+    // `user_filter` is applied in poll() (shared with the Emby adapter), not here.
     return sessions.filter((s) => s.NowPlayingItem && isScrobblableType(s.NowPlayingItem.Type))
   }
 }

--- a/tests/unit/jellyfin.test.ts
+++ b/tests/unit/jellyfin.test.ts
@@ -1,5 +1,5 @@
-﻿import { describe, it, expect, beforeEach, afterEach, vi } from 'vite-plus/test'
-import { JellyfinAdapter } from '../../src/adapters/jellyfin.js'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vite-plus/test'
+import { JellyfinAdapter, matchesUserFilter } from '../../src/adapters/jellyfin.js'
 import { EmbyAdapter } from '../../src/adapters/emby.js'
 import type { SourceConfig, NormalizedEvent } from '../../src/types.js'
 import type { BaseAdapter } from '../../src/adapters/base.js'
@@ -341,6 +341,66 @@ describe('JellyfinAdapter polling diff', () => {
       },
     })
   })
+
+  it('drops sessions of other users when a hidden user_filter is set', async () => {
+    const emitted: NormalizedEvent[] = []
+    const config = { ...makeConfig('jellyfin'), userFilter: ['JuFrolov'] }
+    const adapter = new JellyfinAdapter(config, {
+      onScrobble: async (e) => {
+        emitted.push(e)
+      },
+      onLog: () => {},
+    })
+    ;(adapter as unknown as { running: boolean }).running = true
+
+    const mine = { ...baseSession, Id: 'mine', UserId: 'user1', UserName: 'JuFrolov' }
+    const theirs = {
+      ...baseSession,
+      Id: 'theirs',
+      UserId: 'user2',
+      UserName: 'SomeoneElse',
+      NowPlayingItem: { ...baseSession.NowPlayingItem, Id: 'item-2' },
+    }
+
+    vi.stubGlobal(
+      'fetch',
+      routedFetch({
+        '/Sessions': () => sessionsResponse([mine, theirs]),
+        '/Items/item-1': () => itemResponse(baseSession.NowPlayingItem),
+        '/Items/item-2': () => itemResponse(theirs.NowPlayingItem),
+      }),
+    )
+
+    await tick(adapter)
+
+    expect(emitted).toHaveLength(1)
+    expect(emitted[0].sessionId).toBe('mine:item:item-1')
+  })
+
+  it('an empty user_filter counts every viewer', async () => {
+    const emitted: NormalizedEvent[] = []
+    const adapter = new JellyfinAdapter(makeConfig('jellyfin'), {
+      onScrobble: async (e) => {
+        emitted.push(e)
+      },
+      onLog: () => {},
+    })
+    ;(adapter as unknown as { running: boolean }).running = true
+
+    const someone = { ...baseSession, Id: 'someone', UserId: 'user2', UserName: 'SomeoneElse' }
+
+    vi.stubGlobal(
+      'fetch',
+      routedFetch({
+        '/Sessions': () => sessionsResponse([someone]),
+        '/Items/item-1': () => itemResponse(baseSession.NowPlayingItem),
+      }),
+    )
+
+    await tick(adapter)
+
+    expect(emitted).toHaveLength(1)
+  })
 })
 
 describe('EmbyAdapter inherits Jellyfin polling', () => {
@@ -376,5 +436,76 @@ describe('EmbyAdapter inherits Jellyfin polling', () => {
     expect(emitted[0].source).toBe('emby')
     expect(emitted[0].sessionId).toBe('sess-1:item:item-1')
     expect(emitted[0].action).toBe('progress')
+  })
+})
+
+describe('matchesUserFilter', () => {
+  it('accepts any user when the filter is empty', () => {
+    expect(matchesUserFilter({ id: 'x', title: 'y' }, [])).toBe(true)
+    expect(matchesUserFilter(undefined, [])).toBe(true)
+  })
+
+  it('matches by id (trim + case-insensitive)', () => {
+    expect(matchesUserFilter({ id: 'USER1' }, ['  user1 '])).toBe(true)
+    expect(matchesUserFilter({ id: 'other' }, ['user1'])).toBe(false)
+  })
+
+  it('matches by title (trim + case-insensitive)', () => {
+    expect(matchesUserFilter({ title: ' Griff ' }, ['griff'])).toBe(true)
+  })
+
+  it('drops a session with no user info when a filter is set', () => {
+    expect(matchesUserFilter(undefined, ['user1'])).toBe(false)
+    expect(matchesUserFilter({}, ['user1'])).toBe(false)
+  })
+})
+
+describe('EmbyAdapter applies user_filter (regression)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('scrobbles only the filtered viewer, dropping other users', async () => {
+    const mine = {
+      ...baseSession,
+      Id: 'sess-mine',
+      UserId: 'me',
+      UserName: 'Me',
+    }
+    const theirs = {
+      ...baseSession,
+      Id: 'sess-theirs',
+      UserId: 'someone-else',
+      UserName: 'Someone Else',
+      NowPlayingItem: { ...baseSession.NowPlayingItem, Id: 'item-2' },
+    }
+
+    const emitted: NormalizedEvent[] = []
+    const config: SourceConfig = { ...makeConfig('emby'), userFilter: ['me'] }
+    const adapter = new EmbyAdapter(config, {
+      onScrobble: async (e) => {
+        emitted.push(e)
+      },
+      onLog: () => {},
+    })
+    ;(adapter as unknown as { running: boolean }).running = true
+
+    vi.stubGlobal(
+      'fetch',
+      routedFetch({
+        '/Sessions': () => sessionsResponse([mine, theirs]),
+        '/Items/item-1': () => itemResponse(baseSession.NowPlayingItem),
+        '/Items/item-2': () => itemResponse(theirs.NowPlayingItem),
+      }),
+    )
+
+    await tick(adapter)
+
+    // Only the filtered-in viewer's session produces a scrobble; the other user is dropped.
+    expect(emitted).toHaveLength(1)
+    expect(emitted[0].sessionId).toBe('sess-mine:item:item-1')
   })
 })


### PR DESCRIPTION
Fixes #30.

Upstream only applies `user_filter` to the Plex adapter. The Jellyfin and Emby adapters pull every active server session regardless of config, so on a shared server all viewers get scrobbled — which is what #30 reports for Emby (and the same is true for Jellyfin).

### Change
Apply `matchesUserFilter` (mirrored from `adapters/plex.ts`) inside the shared `poll()`, so both the Jellyfin adapter and the Emby adapter honour it from one place. Emby overrides `fetchSessions()`, so a filter placed there would be silently skipped — `poll()` is the common point both go through.

- Matches by `UserId` **or** `UserName` (trimmed, case-insensitive).
- Empty `user_filter` keeps current behaviour (every viewer counts).
- Config plumbing already exists (`config.userFilter` <- `user_filter`), so this touches only the adapter and its tests.

### Usage
```json
"user_filter": ["YourJellyfinUsername"]
```
(a user id also works)

### Tests
Adds unit tests for `matchesUserFilter` and an Emby regression test proving other users are dropped. `vitest run tests/unit/jellyfin.test.ts` — 13 passing.

Background: extracted from a personal fork; this PR contains only the `user_filter` change, nothing else.