### PR TITLE
fix(plex): keep show id on stop scrobble for legacy episodes, don't cache empty metadata

### DIFF
--- a/src/adapters/external-ids.ts
+++ b/src/adapters/external-ids.ts
@@ -130,17 +130,6 @@ export function legacyIdFields(ids: ExternalIds): {
   }
 }
 
-export function extractPrefixedId(
-  guids: PrefixedGuid[] | undefined,
-  prefix: string,
-): string | null {
-  if (!Array.isArray(guids)) {
-    return null
-  }
-  const match = guids.find((guid) => guid.id?.startsWith(prefix))
-  return match ? (match.id?.replace(prefix, '') ?? null) : null
-}
-
 /** Prefix used by every retired Plex metadata agent. */
 const PLEX_LEGACY_PREFIX = 'com.plexapp.agents.'
 const HAMA_AGENT = 'hama'

--- a/src/adapters/plex.ts
+++ b/src/adapters/plex.ts
@@ -356,7 +356,7 @@ export class PlexAdapter extends BaseAdapter {
         const showMeta = prev.type === 'episode' ? await this.getShowMeta(prev) : null
         const episodeMeta =
           prev.type === 'episode' ? await this.getEpisodeMeta(prev.ratingKey) : null
-        const rating = await this.fetchMetadataWithRating(prev.ratingKey)
+        const rating = await this.fetchMetadataWithRating(prev.ratingKey, prev.type)
         const partFile = prev.Media?.[0]?.Part?.[0]?.file ?? null
         const event = sessionToEvent(
           prev,
@@ -468,13 +468,17 @@ export class PlexAdapter extends BaseAdapter {
 
       const data = (await response.json()) as PlexMetadataResponse
       const meta = data.MediaContainer?.Metadata?.[0]
+      if (!meta) {
+        // An empty container is transient (Plex mid-scan/refresh), not a legacy library —
+        // leave it uncached so the next tick retries.
+        return null
+      }
 
       // Episode ids come from `Guid[]` only. The scalar `guid` of a legacy episode is the
       // *show* id plus season/episode numbers, so feeding it here would scrobble the wrong
-      // thing — see docs/plex-legacy-guids-research.md §5.1. The asymmetry with
-      // getShowMeta/getMovieMeta is deliberate.
+      // thing. The asymmetry with getShowMeta/getMovieMeta is deliberate.
       const episodeMeta: EpisodeMeta = {
-        guids: meta?.Guid ?? [],
+        guids: meta.Guid ?? [],
       }
 
       // Cached even when empty: legacy libraries never return `Guid[]`, and bailing out
@@ -518,11 +522,15 @@ export class PlexAdapter extends BaseAdapter {
 
       const data = (await response.json()) as PlexMetadataResponse
       const meta = data.MediaContainer?.Metadata?.[0]
+      if (!meta) {
+        // Transient empty container — see getEpisodeMeta.
+        return null
+      }
 
       // Only the top-level item is read. `Related` and `Extras` in the same response carry
-      // GUIDs of *other* titles — see docs/plex-legacy-guids-research.md §11.5.
+      // GUIDs of *other* titles and must never be consulted.
       const movieMeta: MovieMeta = {
-        guids: firstNonEmpty(meta?.Guid, scalarGuids(meta?.guid)),
+        guids: firstNonEmpty(meta.Guid, scalarGuids(meta.guid)),
       }
 
       // Cached even when empty, for the same reason as getEpisodeMeta.
@@ -578,7 +586,10 @@ export class PlexAdapter extends BaseAdapter {
     }))
   }
 
-  private async fetchMetadataWithRating(ratingKey: string): Promise<{
+  private async fetchMetadataWithRating(
+    ratingKey: string,
+    type: PlexSession['type'],
+  ): Promise<{
     userRating: number | null
     guids?: PlexGuid[]
   } | null> {
@@ -605,8 +616,15 @@ export class PlexAdapter extends BaseAdapter {
       return {
         userRating: metadata.userRating ?? null,
         // This is the session-end path, which produces the scrobble that actually counts —
-        // it needs the legacy scalar just as much as the in-progress paths do.
-        guids: firstNonEmpty(metadata.Guid, scalarGuids(metadata.guid)),
+        // it needs the legacy scalar just as much as the in-progress paths do. But only for
+        // movies: an episode's scalar `guid` is the show id plus season/episode numbers (or a
+        // meaningless `local://` id under HAMA). Wrapping it here would make a non-empty
+        // array that wins the fallback chain in sessionToEvent over `grandparentGuid`, and
+        // the stop scrobble would lose the show id whenever show metadata is unavailable.
+        guids:
+          type === 'episode'
+            ? (metadata.Guid ?? [])
+            : firstNonEmpty(metadata.Guid, scalarGuids(metadata.guid)),
       }
     } catch (err) {
       this.log('error', `Metadata fetch error: ${(err as Error).message}`)

--- a/src/adapters/plex.ts
+++ b/src/adapters/plex.ts
@@ -71,7 +71,6 @@ interface PlexSession {
    * used — `grandparentGuid` is the clean show id. See external-ids.normalizeGuid.
    */
   guid?: string
-  parentGuid?: string
   grandparentGuid?: string
   Media?: PlexMedia[]
   User?: { id: string; title: string }
@@ -89,7 +88,6 @@ interface PlexMetadataResponse {
       lastRatedAt?: number
       Guid?: PlexGuid[]
       guid?: string
-      parentGuid?: string
       grandparentGuid?: string
     }>
   }
@@ -340,7 +338,11 @@ export class PlexAdapter extends BaseAdapter {
             undefined,
             partFile,
           )
-          this.logResolvedIds(event)
+          // Metadata is cached per item, so ids stay the same across plain progress ticks —
+          // only log them again on a state transition, not on every viewOffset advance.
+          if (label !== 'progress') {
+            this.logResolvedIds(event)
+          }
           await this.emitScrobble(event)
         }
       }

--- a/tests/e2e/mock-plex-server.ts
+++ b/tests/e2e/mock-plex-server.ts
@@ -76,6 +76,8 @@ export function startMockPlexServer(port: number): MockPlexServer {
               {
                 userRating: null,
                 Guid: match?.Guid ?? [],
+                guid: match?.guid,
+                grandparentGuid: match?.grandparentGuid,
               },
             ],
           },

--- a/tests/unit/plex.test.ts
+++ b/tests/unit/plex.test.ts
@@ -413,7 +413,6 @@ describe('PlexAdapter polling diff', () => {
 /**
  * Libraries built on retired metadata agents never send `Guid[]`; the id arrives in the
  * scalar `guid` / `grandparentGuid` attributes instead.
- * See docs/superpowers/specs/2026-07-27-plex-legacy-guids-design.md.
  */
 describe('PlexAdapter legacy agent libraries', () => {
   const SHOW_GUID = 'com.plexapp.agents.thetvdb://468006?lang=en'
@@ -591,6 +590,65 @@ describe('PlexAdapter legacy agent libraries', () => {
 
     const stopped = emitted.find((e) => e.action === 'stopped')
     expect(stopped).toMatchObject({ ids: { imdb: 'tt29768334' } })
+  })
+
+  it('keeps the show id on the session-end scrobble when show metadata is unavailable', async () => {
+    // Show metadata fails on both ticks, but the episode's own metadata succeeds. The
+    // episode scalar carries the show id plus S/E numbers (or a `local://` id under HAMA),
+    // so it must not shadow `grandparentGuid` on the stop path.
+    for (const episodeGuid of [EPISODE_GUID, 'local://60239']) {
+      const emitted: NormalizedEvent[] = []
+      const adapter = startedAdapter(emitted)
+
+      let sessions: unknown[] = [{ ...legacyEpisodeSession, guid: episodeGuid }]
+      vi.stubGlobal(
+        'fetch',
+        routedFetch({
+          '/status/sessions': () => sessionsResponse(sessions),
+          '/library/metadata/60239': () => metadataResponse([{ guid: episodeGuid }]),
+          // No route for /library/metadata/60237 — show metadata 404s.
+        }),
+      )
+
+      await tick(adapter)
+      sessions = []
+      await tick(adapter)
+
+      const stopped = emitted.find((e) => e.action === 'stopped')
+      expect(stopped).toMatchObject({ ids: { tvdb: '468006' }, tvdbId: '468006' })
+      expect(stopped?.episodeIds).toEqual({})
+    }
+  })
+
+  it('retries instead of caching when the metadata container is empty', async () => {
+    // A 200 with no `Metadata` is Plex mid-scan/refresh, not a legacy library. Pinning
+    // `{ guids: [] }` for the session would strip ids from every later scrobble.
+    const emitted: NormalizedEvent[] = []
+    const adapter = startedAdapter(emitted)
+
+    let movieFetches = 0
+    let viewOffset = 100000
+    vi.stubGlobal('fetch', ((url: string) => {
+      if (url.includes('/status/sessions')) {
+        viewOffset += 50000
+        return Promise.resolve(sessionsResponse([{ ...legacyMovieSession, viewOffset }]))
+      }
+      if (url.includes('/library/metadata/59121')) {
+        movieFetches += 1
+        return Promise.resolve(
+          movieFetches === 1 ? metadataResponse([]) : metadataResponse([{ guid: MOVIE_GUID }]),
+        )
+      }
+      return Promise.resolve(new Response('{}', { status: 404 }))
+    }) as typeof fetch)
+
+    await tick(adapter)
+    await tick(adapter)
+    await tick(adapter)
+
+    expect(emitted.map((e) => e.ids)).toEqual([{}, { imdb: 'tt29768334' }, { imdb: 'tt29768334' }])
+    // First response was empty and not cached; second was cached.
+    expect(movieFetches).toBe(2)
   })
 
   it('caches metadata for legacy items instead of refetching on every tick', async () => {

--- a/tests/unit/plex.test.ts
+++ b/tests/unit/plex.test.ts
@@ -67,23 +67,26 @@ function routedFetch(routes: Record<string, () => Response>): typeof fetch {
   }) as typeof fetch
 }
 
+async function tick(adapter: PlexAdapter): Promise<void> {
+  // Use the private poll via access — cast to any to reach the protected member.
+  await (adapter as unknown as { poll(): Promise<void> }).poll()
+}
+
+function startedAdapter(emitted: NormalizedEvent[]): PlexAdapter {
+  const adapter = makeAdapter(emitted)
+  ;(adapter as unknown as { running: boolean }).running = true
+  return adapter
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn())
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
 describe('PlexAdapter polling diff', () => {
-  let fetchMock: ReturnType<typeof vi.fn>
-
-  beforeEach(() => {
-    fetchMock = vi.fn()
-    vi.stubGlobal('fetch', fetchMock)
-  })
-
-  afterEach(() => {
-    vi.unstubAllGlobals()
-  })
-
-  async function tick(adapter: PlexAdapter): Promise<void> {
-    // Use the private poll via access — cast to any to reach the protected member.
-    await (adapter as unknown as { poll(): Promise<void> }).poll()
-  }
-
   it('emits progress for every new session on the first tick', async () => {
     const emitted: NormalizedEvent[] = []
     const adapter = makeAdapter(emitted)
@@ -447,24 +450,6 @@ describe('PlexAdapter legacy agent libraries', () => {
     Player: { state: 'playing' },
   }
 
-  beforeEach(() => {
-    vi.stubGlobal('fetch', vi.fn())
-  })
-
-  afterEach(() => {
-    vi.unstubAllGlobals()
-  })
-
-  async function tick(adapter: PlexAdapter): Promise<void> {
-    await (adapter as unknown as { poll(): Promise<void> }).poll()
-  }
-
-  function startedAdapter(emitted: NormalizedEvent[]): PlexAdapter {
-    const adapter = makeAdapter(emitted)
-    ;(adapter as unknown as { running: boolean }).running = true
-    return adapter
-  }
-
   it('takes the show id from the scalar GUID and leaves episode ids empty', async () => {
     const emitted: NormalizedEvent[] = []
     const adapter = startedAdapter(emitted)
@@ -682,208 +667,191 @@ describe('PlexAdapter legacy agent libraries', () => {
     expect(calls.filter((url) => url.includes('/library/metadata/60237'))).toHaveLength(1)
     expect(emitted).toHaveLength(2)
   })
-})
 
-/**
- * Cases reported in https://github.com/myshowsme/myshows-scrobbler/issues/24 by a user
- * running the diagnostics build against a real HAMA-agent library (issue comment,
- * 2026-08-27). All of them were already handled correctly by the code above — these
- * tests pin that down so a future change can't silently regress it.
- */
-describe('PlexAdapter HAMA agent libraries', () => {
-  beforeEach(() => {
-    vi.stubGlobal('fetch', vi.fn())
-  })
+  /**
+   * Cases reported in https://github.com/myshowsme/myshows-scrobbler/issues/24 by a user
+   * running the diagnostics build against a real HAMA-agent library (issue comment,
+   * 2026-08-27). All of them were already handled correctly by the code above — these
+   * tests pin that down so a future change can't silently regress it. HAMA is itself a
+   * retired metadata agent, so it shares this suite's fixtures and setup.
+   */
+  describe('HAMA agent libraries', () => {
+    it('resolves a HamaTV episode configured in tvdb mode (Goodbye, Lara S1E1)', async () => {
+      const emitted: NormalizedEvent[] = []
+      const adapter = startedAdapter(emitted)
 
-  afterEach(() => {
-    vi.unstubAllGlobals()
-  })
+      const session = {
+        sessionKey: 'k-hama-tvdb',
+        ratingKey: '60527',
+        grandparentRatingKey: '60522',
+        type: 'episode',
+        title: 'Mermaid Princess Lara',
+        grandparentTitle: 'Goodbye, Lara',
+        parentIndex: 1,
+        index: 1,
+        duration: 1400000,
+        viewOffset: 100000,
+        guid: 'com.plexapp.agents.hama://tvdb-450228/1/1?lang=en',
+        parentGuid: 'com.plexapp.agents.hama://tvdb-450228/1?lang=en',
+        grandparentGuid: 'com.plexapp.agents.hama://tvdb-450228?lang=en',
+        Player: { state: 'playing' },
+      }
 
-  async function tick(adapter: PlexAdapter): Promise<void> {
-    await (adapter as unknown as { poll(): Promise<void> }).poll()
-  }
+      vi.stubGlobal(
+        'fetch',
+        routedFetch({
+          '/status/sessions': () => sessionsResponse([session]),
+          '/library/metadata/60522': () =>
+            metadataResponse([{ guid: 'com.plexapp.agents.hama://tvdb-450228?lang=en' }]),
+          '/library/metadata/60527': () => metadataResponse([{}]),
+        }),
+      )
 
-  function startedAdapter(emitted: NormalizedEvent[]): PlexAdapter {
-    const adapter = makeAdapter(emitted)
-    ;(adapter as unknown as { running: boolean }).running = true
-    return adapter
-  }
+      await tick(adapter)
 
-  it('resolves a HamaTV episode configured in tvdb mode (Goodbye, Lara S1E1)', async () => {
-    const emitted: NormalizedEvent[] = []
-    const adapter = startedAdapter(emitted)
+      expect(emitted[0]).toMatchObject({ ids: { tvdb: '450228' }, tvdbId: '450228' })
+    })
 
-    const session = {
-      sessionKey: 'k-hama-tvdb',
-      ratingKey: '60527',
-      grandparentRatingKey: '60522',
-      type: 'episode',
-      title: 'Mermaid Princess Lara',
-      grandparentTitle: 'Goodbye, Lara',
-      parentIndex: 1,
-      index: 1,
-      duration: 1400000,
-      viewOffset: 100000,
-      guid: 'com.plexapp.agents.hama://tvdb-450228/1/1?lang=en',
-      parentGuid: 'com.plexapp.agents.hama://tvdb-450228/1?lang=en',
-      grandparentGuid: 'com.plexapp.agents.hama://tvdb-450228?lang=en',
-      Player: { state: 'playing' },
-    }
+    it('resolves the same HamaTV show configured in anidb mode instead', async () => {
+      const emitted: NormalizedEvent[] = []
+      const adapter = startedAdapter(emitted)
 
-    vi.stubGlobal(
-      'fetch',
-      routedFetch({
-        '/status/sessions': () => sessionsResponse([session]),
-        '/library/metadata/60522': () =>
-          metadataResponse([{ guid: 'com.plexapp.agents.hama://tvdb-450228?lang=en' }]),
-        '/library/metadata/60527': () => metadataResponse([{}]),
-      }),
-    )
+      const session = {
+        sessionKey: 'k-hama-anidb',
+        ratingKey: '60524',
+        grandparentRatingKey: '60522',
+        type: 'episode',
+        title: 'Running Through Shiga',
+        grandparentTitle: 'Sayonara Lara',
+        parentIndex: 1,
+        index: 2,
+        duration: 1400000,
+        viewOffset: 100000,
+        guid: 'com.plexapp.agents.hama://anidb-18643/1/2?lang=en',
+        parentGuid: 'com.plexapp.agents.hama://anidb-18643/1?lang=en',
+        grandparentGuid: 'com.plexapp.agents.hama://anidb-18643?lang=en',
+        Player: { state: 'playing' },
+      }
 
-    await tick(adapter)
+      vi.stubGlobal(
+        'fetch',
+        routedFetch({
+          '/status/sessions': () => sessionsResponse([session]),
+          '/library/metadata/60522': () =>
+            metadataResponse([{ guid: 'com.plexapp.agents.hama://anidb-18643?lang=en' }]),
+          '/library/metadata/60524': () => metadataResponse([{}]),
+        }),
+      )
 
-    expect(emitted[0]).toMatchObject({ ids: { tvdb: '450228' }, tvdbId: '450228' })
-  })
+      await tick(adapter)
 
-  it('resolves the same HamaTV show configured in anidb mode instead', async () => {
-    const emitted: NormalizedEvent[] = []
-    const adapter = startedAdapter(emitted)
+      expect(emitted[0]).toMatchObject({ ids: { anidb: 18643 } })
+    })
 
-    const session = {
-      sessionKey: 'k-hama-anidb',
-      ratingKey: '60524',
-      grandparentRatingKey: '60522',
-      type: 'episode',
-      title: 'Running Through Shiga',
-      grandparentTitle: 'Sayonara Lara',
-      parentIndex: 1,
-      index: 2,
-      duration: 1400000,
-      viewOffset: 100000,
-      guid: 'com.plexapp.agents.hama://anidb-18643/1/2?lang=en',
-      parentGuid: 'com.plexapp.agents.hama://anidb-18643/1?lang=en',
-      grandparentGuid: 'com.plexapp.agents.hama://anidb-18643?lang=en',
-      Player: { state: 'playing' },
-    }
+    it('falls back to grandparentGuid when the episode-level guid is a meaningless local:// id (multi-season HAMA)', async () => {
+      const emitted: NormalizedEvent[] = []
+      const adapter = startedAdapter(emitted)
 
-    vi.stubGlobal(
-      'fetch',
-      routedFetch({
-        '/status/sessions': () => sessionsResponse([session]),
-        '/library/metadata/60522': () =>
-          metadataResponse([{ guid: 'com.plexapp.agents.hama://anidb-18643?lang=en' }]),
-        '/library/metadata/60524': () => metadataResponse([{}]),
-      }),
-    )
+      // Real-world shape: HAMA's scanner assigns `local://` guids per-episode once a show
+      // has multiple seasons; the actual provider id only survives on grandparentGuid.
+      const session = {
+        sessionKey: 'k-hama-local',
+        ratingKey: '60293',
+        grandparentRatingKey: '60291',
+        type: 'episode',
+        title: '2026-07-04',
+        grandparentTitle: 'Mushoku Tensei: Jobless Reincarnation',
+        parentIndex: 3,
+        index: 1,
+        duration: 1400000,
+        viewOffset: 100000,
+        guid: 'local://60293',
+        parentGuid: 'local://60292',
+        grandparentGuid: 'com.plexapp.agents.hama://tvdb-371310?lang=en',
+        Player: { state: 'playing' },
+      }
 
-    await tick(adapter)
+      vi.stubGlobal(
+        'fetch',
+        routedFetch({
+          '/status/sessions': () => sessionsResponse([session]),
+          '/library/metadata/60291': () =>
+            metadataResponse([{ guid: 'com.plexapp.agents.hama://tvdb-371310?lang=en' }]),
+          '/library/metadata/60293': () => metadataResponse([{}]),
+        }),
+      )
 
-    expect(emitted[0]).toMatchObject({ ids: { anidb: 18643 } })
-  })
+      await tick(adapter)
 
-  it('falls back to grandparentGuid when the episode-level guid is a meaningless local:// id (multi-season HAMA)', async () => {
-    const emitted: NormalizedEvent[] = []
-    const adapter = startedAdapter(emitted)
+      expect(emitted[0]).toMatchObject({ ids: { tvdb: '371310' }, tvdbId: '371310' })
+    })
 
-    // Real-world shape: HAMA's scanner assigns `local://` guids per-episode once a show
-    // has multiple seasons; the actual provider id only survives on grandparentGuid.
-    const session = {
-      sessionKey: 'k-hama-local',
-      ratingKey: '60293',
-      grandparentRatingKey: '60291',
-      type: 'episode',
-      title: '2026-07-04',
-      grandparentTitle: 'Mushoku Tensei: Jobless Reincarnation',
-      parentIndex: 3,
-      index: 1,
-      duration: 1400000,
-      viewOffset: 100000,
-      guid: 'local://60293',
-      parentGuid: 'local://60292',
-      grandparentGuid: 'com.plexapp.agents.hama://tvdb-371310?lang=en',
-      Player: { state: 'playing' },
-    }
+    it('resolves a HamaMovies title in anidb mode', async () => {
+      const emitted: NormalizedEvent[] = []
+      const adapter = startedAdapter(emitted)
 
-    vi.stubGlobal(
-      'fetch',
-      routedFetch({
-        '/status/sessions': () => sessionsResponse([session]),
-        '/library/metadata/60291': () =>
-          metadataResponse([{ guid: 'com.plexapp.agents.hama://tvdb-371310?lang=en' }]),
-        '/library/metadata/60293': () => metadataResponse([{}]),
-      }),
-    )
+      const session = {
+        sessionKey: 'k-hama-movie',
+        ratingKey: '54357',
+        type: 'movie',
+        title: 'Gekijouban Pocket Monsters: Kimi ni Kimeta!',
+        year: 2017,
+        duration: 1400000,
+        viewOffset: 100000,
+        Player: { state: 'playing' },
+        // /status/sessions never returns Guid[] for legacy movies either.
+      }
 
-    await tick(adapter)
+      vi.stubGlobal(
+        'fetch',
+        routedFetch({
+          '/status/sessions': () => sessionsResponse([session]),
+          '/library/metadata/54357': () =>
+            metadataResponse([{ guid: 'com.plexapp.agents.hama://anidb-12646?lang=en' }]),
+        }),
+      )
 
-    expect(emitted[0]).toMatchObject({ ids: { tvdb: '371310' }, tvdbId: '371310' })
-  })
+      await tick(adapter)
 
-  it('resolves a HamaMovies title in anidb mode', async () => {
-    const emitted: NormalizedEvent[] = []
-    const adapter = startedAdapter(emitted)
+      expect(emitted[0]).toMatchObject({ type: 'movie', ids: { anidb: 12646 } })
+    })
 
-    const session = {
-      sessionKey: 'k-hama-movie',
-      ratingKey: '54357',
-      type: 'movie',
-      title: 'Gekijouban Pocket Monsters: Kimi ni Kimeta!',
-      year: 2017,
-      duration: 1400000,
-      viewOffset: 100000,
-      Player: { state: 'playing' },
-      // /status/sessions never returns Guid[] for legacy movies either.
-    }
+    it('resolves an anime movie filed under HamaTV inside a TV library (local:// episode wrapping a movie)', async () => {
+      const emitted: NormalizedEvent[] = []
+      const adapter = startedAdapter(emitted)
 
-    vi.stubGlobal(
-      'fetch',
-      routedFetch({
-        '/status/sessions': () => sessionsResponse([session]),
-        '/library/metadata/54357': () =>
-          metadataResponse([{ guid: 'com.plexapp.agents.hama://anidb-12646?lang=en' }]),
-      }),
-    )
+      // HAMA's popular "movie as a single-episode show" layout for TV libraries: the
+      // episode's own guid is another meaningless local:// id, same fallback as above.
+      const session = {
+        sessionKey: 'k-hama-movie-in-tv',
+        ratingKey: '60917',
+        grandparentRatingKey: '60915',
+        type: 'episode',
+        title: 'Episode 1',
+        grandparentTitle: 'Pokemon the Movie: I Choose You!',
+        parentIndex: 1,
+        index: 1,
+        duration: 1400000,
+        viewOffset: 100000,
+        guid: 'local://60917',
+        parentGuid: 'local://60916',
+        grandparentGuid: 'com.plexapp.agents.hama://anidb-12646?lang=en',
+        Player: { state: 'playing' },
+      }
 
-    await tick(adapter)
+      vi.stubGlobal(
+        'fetch',
+        routedFetch({
+          '/status/sessions': () => sessionsResponse([session]),
+          '/library/metadata/60915': () =>
+            metadataResponse([{ guid: 'com.plexapp.agents.hama://anidb-12646?lang=en' }]),
+          '/library/metadata/60917': () => metadataResponse([{}]),
+        }),
+      )
 
-    expect(emitted[0]).toMatchObject({ type: 'movie', ids: { anidb: 12646 } })
-  })
+      await tick(adapter)
 
-  it('resolves an anime movie filed under HamaTV inside a TV library (local:// episode wrapping a movie)', async () => {
-    const emitted: NormalizedEvent[] = []
-    const adapter = startedAdapter(emitted)
-
-    // HAMA's popular "movie as a single-episode show" layout for TV libraries: the
-    // episode's own guid is another meaningless local:// id, same fallback as above.
-    const session = {
-      sessionKey: 'k-hama-movie-in-tv',
-      ratingKey: '60917',
-      grandparentRatingKey: '60915',
-      type: 'episode',
-      title: 'Episode 1',
-      grandparentTitle: 'Pokemon the Movie: I Choose You!',
-      parentIndex: 1,
-      index: 1,
-      duration: 1400000,
-      viewOffset: 100000,
-      guid: 'local://60917',
-      parentGuid: 'local://60916',
-      grandparentGuid: 'com.plexapp.agents.hama://anidb-12646?lang=en',
-      Player: { state: 'playing' },
-    }
-
-    vi.stubGlobal(
-      'fetch',
-      routedFetch({
-        '/status/sessions': () => sessionsResponse([session]),
-        '/library/metadata/60915': () =>
-          metadataResponse([{ guid: 'com.plexapp.agents.hama://anidb-12646?lang=en' }]),
-        '/library/metadata/60917': () => metadataResponse([{}]),
-      }),
-    )
-
-    await tick(adapter)
-
-    expect(emitted[0]).toMatchObject({ ids: { anidb: 12646 } })
+      expect(emitted[0]).toMatchObject({ ids: { anidb: 12646 } })
+    })
   })
 })


### PR DESCRIPTION
Доработки по ревью #40 (base — `feat/plex-legacy-guids`, после мержа изменения попадут в тот PR).

## Что исправлено

**1. Финальный (stopped) скробл терял show id у legacy-эпизода, если show-метадата недоступна**

`fetchMetadataWithRating` оборачивал собственный скалярный `guid` эпизода (`com.plexapp.agents.thetvdb://468006/1/1` или HAMA `local://…`) в непустой массив. В `sessionToEvent` этот массив выигрывал в `firstNonEmpty(showMeta?.guids, extraGuids, sessionGuids(meta))` у `grandparentGuid`, `normalizeGuid` отбрасывал его из-за `/`, и событие `stopped` уходило с `ids: {}`, хотя progress-события несли `tvdb: 468006`.

Воспроизведено: show meta → 404 на обоих тиках, episode meta → `{ guid: EPISODE_GUID }` ⇒ `progress ids = { tvdb: '468006' }`, `stopped ids = {}`.

Фикс: `fetchMetadataWithRating` получает `type` сессии; для эпизодов используется только `Guid[]` — то же правило, что уже применяет `getEpisodeMeta`.

**2. Пустой контейнер метадаты кэшировался на всю сессию**

`getEpisodeMeta` / `getMovieMeta` кэшировали `{ guids: [] }` даже когда `MediaContainer.Metadata` отсутствовал целиком (Plex во время скана/refresh отвечает 200 с пустым контейнером). Раньше возвращался `null` и на следующем тике был повтор.

Воспроизведено: первый ответ `/library/metadata/59121` пустой, дальнейшие содержат `Guid[]` ⇒ `ids` оставались `{}` на всех тиках.

Фикс: `if (!meta) return null` перед кэшированием, как в `getShowMeta`. Реальный item без `Guid[]` (legacy-библиотека) по-прежнему кэшируется.

**3. Битые ссылки на документацию**

Комментарии ссылались на `docs/plex-legacy-guids-research.md §5.1/§11.5` и `docs/superpowers/specs/2026-07-27-plex-legacy-guids-design.md`, которых в репозитории нет. Ссылки убраны, объяснение оставлено inline.

## Тесты

Два регрессионных теста в блоке `PlexAdapter legacy agent libraries`:
- `keeps the show id on the session-end scrobble when show metadata is unavailable` (покрывает и `thetvdb://…/1/1`, и HAMA `local://`)
- `retries instead of caching when the metadata container is empty`

Оба падают на `feat/plex-legacy-guids` без правки исходников и проходят с ней. Полный прогон: 431/431 unit-тестов, `vp check` чистый.
